### PR TITLE
A couple of service-provider merging bugs

### DIFF
--- a/src/main/scala/sbtassembly/Plugin.scala
+++ b/src/main/scala/sbtassembly/Plugin.scala
@@ -75,7 +75,7 @@ object Plugin extends sbt.Plugin {
       IO.delete(ao.exclude(Seq(tempDir)))
       val servicesDir = tempDir / "META-INF" / "services"
       if (servicesDir.asFile.exists) {
-       for (service <- (servicesDir ** "*").get) {
+       for (service <- (servicesDir * "*").get) {
          val serviceFile = service.asFile
          if (serviceFile.exists && serviceFile.isFile) {
            val entries = services.getOrElseUpdate(serviceFile.getName, new mutable.ArrayBuffer[String]())


### PR DESCRIPTION
Ensuring the service files are closed after reading them, and not trying to merge other non-service files that some jars throw into META-INF/services.
