### PR TITLE
More default exclusions and merges

### DIFF
--- a/src/main/scala/sbtassembly/Plugin.scala
+++ b/src/main/scala/sbtassembly/Plugin.scala
@@ -204,6 +204,7 @@ object Plugin extends sbt.Plugin {
     mergeStrategy in assembly := { 
         case "reference.conf" => MergeStrategy.concat
         case n if n.startsWith("META-INF/services/") => MergeStrategy.filterDistinctLines
+        case "META-INF/spring.schemas" | "META-INF/spring.handlers" => MergeStrategy.filterDistinctLines
         case _ => MergeStrategy.deduplicate
       },
 


### PR DESCRIPTION
sbt-assembly has just become more picky about letting random jars overwrite each others' files.  I've collected a set of new exclusions and merges from a large project with dependencies on many (about 70MB worth) of third-party jars.  I think these will prevent almost all real-world collisions that are not jars seemingly actively trying to step on each others' toes (and you would be shocked at the amount of work I've done this morning resolving such conflicts -- importing another system wholesale into yours and not bothering to rename the java packages it lives in seems to be a favored pastime in some parts of the Java world).

Anyway: this excludes more variations on "license", "readme"s, jar signatures (since they won't check after merging anyway; I've had that in my build script for ages but it's probably best to get it upstream), maven-specific stuff, and informational files that some build tools like to stick in meta-inf.  Also it merges spring.schemas and spring.handlers files (see http://static.springsource.org/spring/docs/2.0.x/reference/extensible-xml.html)
