### PR TITLE
use "latest.integration" version in scripted tests

### DIFF
--- a/src/sbt-test/sbt-assembly/config/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/config/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "latest.integration")

--- a/src/sbt-test/sbt-assembly/deps/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/deps/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "latest.integration")

--- a/src/sbt-test/sbt-assembly/empty/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/empty/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "latest.integration")

--- a/src/sbt-test/sbt-assembly/mergefail/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/mergefail/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "latest.integration")

--- a/src/sbt-test/sbt-assembly/mergefail2/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/mergefail2/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "latest.integration")

--- a/src/sbt-test/sbt-assembly/merging/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/merging/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "latest.integration")

--- a/src/sbt-test/sbt-assembly/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/simple/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.8.1-SNAPSHOT")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "latest.integration")


### PR DESCRIPTION
so that it actually picks up the latest version and doesn't test against an old one
