### PR TITLE
Corrected headings in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ libraryDependencies += Defaults.sbtPluginExtra("com.eed3si9n" % "sbt-assembly" %
 Using Git
 ---------
 
+Alternately, you can have sbt checkout and build the plugin's source from version control.
+
 Specify sbt-assembly.git as a dependency in `project/project/build.scala`:
 
 ```scala


### PR DESCRIPTION
The text for using Git does not belong under the "How To Use" heading.

I also reworded two other headings to make it more clear what their
corresponding sections are for and explained that you need to add the
plugin to your build before you can add its settings to a project
