### PR TITLE
Allow the jar name to be computed per-run, not per-sbt-invocation

### DIFF
--- a/src/main/scala/sbtassembly/Plugin.scala
+++ b/src/main/scala/sbtassembly/Plugin.scala
@@ -18,9 +18,8 @@ object Plugin extends sbt.Plugin {
   
     lazy val assembleArtifact  = SettingKey[Boolean]("assembly-assemble-artifact", "Enables (true) or disables (false) assembling an artifact.")
     lazy val assemblyOption    = SettingKey[AssemblyOption]("assembly-option")
-    lazy val jarName           = SettingKey[String]("assembly-jar-name")
-    lazy val defaultJarName    = SettingKey[String]("assembly-default-jar-name")
-    lazy val computedJarName   = TaskKey[String]("assembly-computed-jar-name")
+    lazy val jarName           = TaskKey[String]("assembly-jar-name")
+    lazy val defaultJarName    = TaskKey[String]("assembly-default-jar-name")
     lazy val outputPath        = TaskKey[File]("assembly-output-path")
     lazy val excludedFiles     = SettingKey[Seq[File] => Seq[File]]("assembly-excluded-files")
     lazy val excludedJars      = TaskKey[Classpath]("assembly-excluded-jars")
@@ -381,22 +380,18 @@ object Plugin extends sbt.Plugin {
     },
     
     assemblyDirectory in assembly <<= cacheDirectory / "assembly",
-    outputPath in assembly <<= (target in assembly, computedJarName in assembly) map { (t, s) => t / s },
-    outputPath in packageScala <<= (target in assembly, computedJarName in packageScala) map { (t, s) => t / s },
-    outputPath in packageDependency <<= (target in assembly, computedJarName in packageDependency) map { (t, s) => t / s },
+    outputPath in assembly <<= (target in assembly, jarName in assembly) map { (t, s) => t / s },
+    outputPath in packageScala <<= (target in assembly, jarName in packageScala) map { (t, s) => t / s },
+    outputPath in packageDependency <<= (target in assembly, jarName in packageDependency) map { (t, s) => t / s },
     target in assembly <<= target,
 
-    computedJarName in assembly <<= (jarName in assembly) map { n => n },
-    computedJarName in packageScala <<= (jarName in packageScala) map { n => n },
-    computedJarName in packageDependency <<= (jarName in packageDependency) map { n => n },
-    
     jarName in assembly <<= (jarName in assembly) or (defaultJarName in assembly),
     jarName in packageScala <<= (jarName in packageScala) or (defaultJarName in packageScala),
     jarName in packageDependency <<= (jarName in packageDependency) or (defaultJarName in packageDependency),
 
-    defaultJarName in packageScala <<= (scalaVersion) { (scalaVersion) => "scala-library-" + scalaVersion + "-assembly.jar" },
-    defaultJarName in packageDependency <<= (name, version) { (name, version) => name + "-assembly-" + version + "-deps.jar" },
-    defaultJarName in assembly <<= (name, version) { (name, version) => name + "-assembly-" + version + ".jar" },
+    defaultJarName in packageScala <<= (scalaVersion) map { (scalaVersion) => "scala-library-" + scalaVersion + "-assembly.jar" },
+    defaultJarName in packageDependency <<= (name, version) map { (name, version) => name + "-assembly-" + version + "-deps.jar" },
+    defaultJarName in assembly <<= (name, version) map { (name, version) => name + "-assembly-" + version + ".jar" },
     
     mainClass in assembly <<= mainClass orr (mainClass in Runtime),
     


### PR DESCRIPTION
We use git describe for jar names, so it's nice to not have to restart
SBT after a new commit.
