### PR TITLE
Add a setting allowing to append SHA-1 to the result artifact name

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ To make a jar containing only the dependencies, type
 
 NOTE: If you use [`-jar` option for `java`](http://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html#jar), it will ignore `-cp`, so if you have multiple jars you have to use `-cp` and pass the main class: `java -cp "jar1.jar:jar2.jar" Main`
 
+You can also append SHA-1 fingerprint to the assembly file name, this may help you to determine whether it has changed and, for example, if it's necessary to deploy the dependencies,
+
+```scala
+appendContentHash in assembly-package-dependency := true
+```
+
 ### Caching
 
 By default for performance reasons, the result of unzipping any dependency jars to disk is cached from run-to-run. This feature can be disabled by setting:


### PR DESCRIPTION
Following change adds a new SettingKey: `appendContentHash`. This setting can be set to true for assembly, assembly-package-dependency and assembly-scala tasks. When it's enabled, the result assembly .jar file has additional **SHA-1** fingerprint appended. This fingerprint is calculated basing on the content of all files included in the assembly.
This is extremely useful when you deploy your dependencies separately. You can now verify if anything has changed and ignore uploading of big 'fat jar' if SHA-1 is the same.
