### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ val app = (project in file("app")).
   )
 ```
 
+If you are using `Build.scala`, you also need to add `import sbtassembly.Plugin._`
+in order to gain access to `assemblySettings`.
+
 Now you'll have an awesome new `assembly` task which will compile your project,
 run your tests, and then pack your class files and all your dependencies into a
 single JAR file: `target/scala_X.X.X/projectname-assembly-X.X.X.jar`.


### PR DESCRIPTION
I recently ran into an issue of using `sbt-assembly` inside a `Build.scala`
`assemblySettings` is defined as part of `sbtassembly.Plugin`, so if I don't have `import sbtassembly.Plugin._` inside `Build.scala`, the build will not compile. 

Maybe it's a good idea to add a note about how to set it up in a `Build.scala`?
