### PR TITLE
add one more shell script header with JAVA_OPTS

### DIFF
--- a/src/main/scala/sbtassembly/Plugin.scala
+++ b/src/main/scala/sbtassembly/Plugin.scala
@@ -432,7 +432,9 @@ object Plugin extends sbt.Plugin {
     case _ => MergeStrategy.deduplicate
   }
 
-  val defaultShellScript: Seq[String] = Seq("#!/usr/bin/env sh", """exec java -jar "$0" "$@"""") // "
+  val shellScriptHeader: String = "#!/usr/bin/env sh"
+  val defaultShellScript: Seq[String] =  Seq(shellScriptHeader, """exec java -jar "$0" "$@"""") // "
+  val javaOptsShellScript: Seq[String] = Seq(shellScriptHeader, """exec java $JAVA_OPTS -jar "$0" "$@"""") // "
 
   lazy val baseAssemblySettings: Seq[sbt.Def.Setting[_]] = Seq(
     assembly := Assembly.assemblyTask(assembly).value,


### PR DESCRIPTION
Sometimes it is needed to pass arguments directly to JVM. The simplest way to do that is to use environment variable. I see 3 ways to do that:
1) Do nothing and pass jvm args via workaround like prependShellScript = Some(Seq(defaultShellScript.head, """exec java $JAVA_OPTS -jar "$0" "$@""""))
2) Add $JAVA_OPTS to already existing defaultShellScript
3) Create a separate $JAVA_OPTS aware header
I like the 3rd way. But only if my proposal seems to be reasonable enough :)
