### PR TITLE
Fix defaultMergeStrategy for META-INF/*.RSA signature files

### DIFF
--- a/src/main/scala/sbtassembly/Plugin.scala
+++ b/src/main/scala/sbtassembly/Plugin.scala
@@ -432,7 +432,7 @@ object Plugin extends sbt.Plugin {
       (xs map {_.toLowerCase}) match {
         case ("manifest.mf" :: Nil) | ("index.list" :: Nil) | ("dependencies" :: Nil) =>
           MergeStrategy.discard
-        case ps @ (x :: xs) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") =>
+        case ps @ (x :: xs) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") || ps.last.endsWith(".rsa") =>
           MergeStrategy.discard
         case "plexus" :: xs =>
           MergeStrategy.discard


### PR DESCRIPTION
I've found RSA signatures in the following artifacts:

```
org.eclipse.jetty.orbit/javax.transaction/orbits/javax.transaction-1.1.1.v201105210645.jar:META-INF/ECLIPSEF.RSA
org.eclipse.jetty.orbit/javax.servlet/orbits/javax.servlet-3.0.0.v201112011016.jar:META-INF/ECLIPSEF.RSA
org.eclipse.jetty.orbit/javax.mail.glassfish/orbits/javax.mail.glassfish-1.4.1.v201005082020.jar:META-INF/ECLIPSEF.RSA
org.eclipse.jetty.orbit/javax.activation/orbits/javax.activation-1.1.0.v201105071233.jar:META-INF/ECLIPSEF.RSA
```

It is good to discard them when merge like other signatures.
