### PR TITLE
Add shading support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
 lazy val commonSettings: Seq[Setting[_]] = Seq(
+  version in ThisBuild := "0.13.1-xw-SNAPSHOT",
   git.baseVersion in ThisBuild := "0.13.1",
   organization in ThisBuild := "com.eed3si9n"
 )
 
 lazy val root = (project in file(".")).
-  enablePlugins(GitVersioning).
+  // enablePlugins(GitVersioning).
   settings(commonSettings: _*).
   settings(
     sbtPlugin := true,
@@ -12,7 +13,10 @@ lazy val root = (project in file(".")).
     description := "sbt plugin to create a single fat jar",
     licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-assembly/blob/master/LICENSE")),
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024"),
-    libraryDependencies += "org.scalactic" %% "scalactic" % "2.2.1",
+    libraryDependencies ++= Seq(
+      "org.scalactic" %% "scalactic" % "2.2.1",
+      "org.pantsbuild.jarjar" % "jarjar" % "1.5"
+    ),
     publishArtifact in (Compile, packageBin) := true,
     publishArtifact in (Test, packageBin) := false,
     publishArtifact in (Compile, packageDoc) := false,

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
 lazy val commonSettings: Seq[Setting[_]] = Seq(
-  version in ThisBuild := "0.13.1-xw-SNAPSHOT",
   git.baseVersion in ThisBuild := "0.13.1",
   organization in ThisBuild := "com.eed3si9n"
 )
 
 lazy val root = (project in file(".")).
-  // enablePlugins(GitVersioning).
+  enablePlugins(GitVersioning).
   settings(commonSettings: _*).
   settings(
     sbtPlugin := true,

--- a/src/main/scala/org/pantsbuild/jarjar/JJProcessor.scala
+++ b/src/main/scala/org/pantsbuild/jarjar/JJProcessor.scala
@@ -6,7 +6,20 @@ import scala.collection.JavaConverters._
 
 class JJProcessor(val proc: JarProcessor) {
 
-  def process(entry: EntryStruct): Unit = proc.process(entry)
+  def process(entry: EntryStruct): Boolean = proc.process(entry)
+
+  def getExcludes(): Set[String] = {
+    val field = proc.getClass().getDeclaredField("kp")
+    field.setAccessible(true)
+    val keepProcessor = field.get(proc)
+
+    if (keepProcessor == null) Set()
+    else {
+      val method = proc.getClass().getDeclaredMethod("getExcludes")
+      method.setAccessible(true)
+      method.invoke(proc).asInstanceOf[java.util.Set[String]].asScala.toSet
+    }
+  }
 
 }
 

--- a/src/main/scala/org/pantsbuild/jarjar/JJProcessor.scala
+++ b/src/main/scala/org/pantsbuild/jarjar/JJProcessor.scala
@@ -1,0 +1,18 @@
+package org.pantsbuild.jarjar
+
+import org.pantsbuild.jarjar.ext_util.{EntryStruct, JarProcessor}
+
+import scala.collection.JavaConverters._
+
+class JJProcessor(val proc: JarProcessor) {
+
+  def process(entry: EntryStruct): Unit = proc.process(entry)
+
+}
+
+object JJProcessor {
+
+  def apply(patterns: Seq[PatternElement], verbose: Boolean, skipManifest: Boolean): JJProcessor =
+    new JJProcessor(new MainProcessor(patterns.asJava, verbose, skipManifest))
+
+}

--- a/src/main/scala/sbtassembly/AssemblyKeys.scala
+++ b/src/main/scala/sbtassembly/AssemblyKeys.scala
@@ -12,7 +12,7 @@ trait AssemblyKeys {
   lazy val assemblyPackageScala      = taskKey[File]("Produces the scala artifact.")
   @deprecated("Use assemblyPackageScala", "0.12.0")
   lazy val packageScala              = assemblyPackageScala
-  
+
   lazy val assemblyPackageDependency = taskKey[File]("Produces the dependency artifact.")
   @deprecated("Use assemblyPackageDependency", "0.12.0")
   lazy val packageDependency         = assemblyPackageDependency
@@ -20,11 +20,11 @@ trait AssemblyKeys {
   lazy val assemblyJarName           = taskKey[String]("name of the fat jar")
   @deprecated("Use assemblyJarName", "0.12.0")
   lazy val jarName                   = assemblyJarName
-  
+
   lazy val assemblyDefaultJarName    = taskKey[String]("default name of the fat jar")
   @deprecated("Use assemblyDefaultJarName", "0.12.0")
   lazy val defaultJarName            = assemblyDefaultJarName
-  
+
   lazy val assemblyOutputPath        = taskKey[File]("output path of the fat jar")
   @deprecated("Use assemblyOutputPath", "0.12.0")
   lazy val outputPath                = assemblyOutputPath
@@ -32,10 +32,12 @@ trait AssemblyKeys {
   lazy val assemblyExcludedJars      = taskKey[Classpath]("list of excluded jars")
   @deprecated("Use assemblyExcludedJars", "0.12.0")
   lazy val excludedJars              = assemblyExcludedJars
-  
+
   lazy val assemblyMergeStrategy     = settingKey[String => MergeStrategy]("mapping from archive member path to merge strategy")
   @deprecated("Use assemblyMergeStrategy", "0.12.0")
-  lazy val mergeStrategy             = assemblyMergeStrategy 
+  lazy val mergeStrategy             = assemblyMergeStrategy
+
+  lazy val assemblyShadingRules      = settingKey[Seq[ShadeRule]]("shading rules backed by jarjar")
 }
 object AssemblyKeys extends AssemblyKeys
 

--- a/src/main/scala/sbtassembly/AssemblyKeys.scala
+++ b/src/main/scala/sbtassembly/AssemblyKeys.scala
@@ -37,7 +37,7 @@ trait AssemblyKeys {
   @deprecated("Use assemblyMergeStrategy", "0.12.0")
   lazy val mergeStrategy             = assemblyMergeStrategy
 
-  lazy val assemblyShadingRules      = settingKey[Seq[ShadeRule]]("shading rules backed by jarjar")
+  lazy val assemblyShadingRules      = settingKey[Seq[ShadeRuleConfigured]]("shading rules backed by jarjar")
 }
 object AssemblyKeys extends AssemblyKeys
 

--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -13,9 +13,10 @@ object AssemblyPlugin extends sbt.AutoPlugin {
     val MergeStrategy = sbtassembly.MergeStrategy
     val PathList = sbtassembly.PathList
     val baseAssemblySettings = AssemblyPlugin.baseAssemblySettings
+    val Shader = sbtassembly.Shader
   }
   import autoImport.{ Assembly => _, baseAssemblySettings => _, _ }
-   
+
   val defaultShellScript: Seq[String] = Seq("#!/usr/bin/env sh", """exec java -jar "$0" "$@"""") // "
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = assemblySettings
@@ -32,12 +33,13 @@ object AssemblyPlugin extends sbt.AutoPlugin {
     test in assembly := (test in Test).value,
     test in assemblyPackageScala := (test in assembly).value,
     test in assemblyPackageDependency := (test in assembly).value,
-    
+
     // assemblyOption
     assembleArtifact in packageBin := true,
     assembleArtifact in assemblyPackageScala := true,
     assembleArtifact in assemblyPackageDependency := true,
     assemblyMergeStrategy in assembly := MergeStrategy.defaultMergeStrategy,
+    assemblyShadingRules in assembly := Seq(),
     assemblyExcludedJars in assembly := Nil,
     assemblyOption in assembly := {
       val s = streams.value
@@ -52,7 +54,8 @@ object AssemblyPlugin extends sbt.AutoPlugin {
         cacheOutput        = true,
         cacheUnzip         = true,
         appendContentHash  = false,
-        prependShellScript = None)
+        prependShellScript = None,
+        shadingRules       = (assemblyShadingRules in assembly).value)
     },
 
     assemblyOption in assemblyPackageScala := {
@@ -86,14 +89,14 @@ object AssemblyPlugin extends sbt.AutoPlugin {
     assemblyDefaultJarName in assemblyPackageScala      <<= (scalaVersion) map { (scalaVersion) => "scala-library-" + scalaVersion + "-assembly.jar" },
     assemblyDefaultJarName in assemblyPackageDependency <<= (name, version) map { (name, version) => name + "-assembly-" + version + "-deps.jar" },
     assemblyDefaultJarName in assembly                  <<= (name, version) map { (name, version) => name + "-assembly-" + version + ".jar" },
-    
+
     mainClass in assembly <<= mainClass or (mainClass in Runtime),
-    
+
     fullClasspath in assembly <<= fullClasspath or (fullClasspath in Runtime),
-    
+
     externalDependencyClasspath in assembly <<= externalDependencyClasspath or (externalDependencyClasspath in Runtime)
   )
-  
+
   lazy val assemblySettings: Seq[sbt.Def.Setting[_]] = baseAssemblySettings
 }
 
@@ -109,4 +112,5 @@ case class AssemblyOption(assemblyDirectory: File,
   cacheOutput: Boolean = true,
   cacheUnzip: Boolean = true,
   appendContentHash: Boolean = false,
-  prependShellScript: Option[Seq[String]] = None)
+  prependShellScript: Option[Seq[String]] = None,
+  shadingRules: Seq[ShadeRule] = Seq())

--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -13,7 +13,7 @@ object AssemblyPlugin extends sbt.AutoPlugin {
     val MergeStrategy = sbtassembly.MergeStrategy
     val PathList = sbtassembly.PathList
     val baseAssemblySettings = AssemblyPlugin.baseAssemblySettings
-    val Shader = sbtassembly.Shader
+    val ShadeRule = sbtassembly.ShadeRule
   }
   import autoImport.{ Assembly => _, baseAssemblySettings => _, _ }
 
@@ -113,4 +113,4 @@ case class AssemblyOption(assemblyDirectory: File,
   cacheUnzip: Boolean = true,
   appendContentHash: Boolean = false,
   prependShellScript: Option[Seq[String]] = None,
-  shadingRules: Seq[ShadeRule] = Seq())
+  shadingRules: Seq[ShadeRuleConfigured] = Seq())

--- a/src/main/scala/sbtassembly/Shader.scala
+++ b/src/main/scala/sbtassembly/Shader.scala
@@ -40,7 +40,7 @@ object ShadeRule {
 private[sbtassembly] case class ShadeTarget(toCompiling: Boolean = false, moduleID: Option[ModuleID] = None) {
 
   private[sbtassembly] def isApplicableTo(mod: ModuleID): Boolean =
-    moduleID.isDefined && mod.equals(moduleID)
+    moduleID.isDefined && mod.equals(moduleID.get)
 
 }
 

--- a/src/main/scala/sbtassembly/Shader.scala
+++ b/src/main/scala/sbtassembly/Shader.scala
@@ -48,7 +48,7 @@ private[sbtassembly] object Shader {
 
   import ShadeRule._
 
-  private[sbtassembly] def shadeDirectory(rules: Seq[ShadeRuleConfigured], dir: File, log: Logger): Unit = {
+  def shadeDirectory(rules: Seq[ShadeRuleConfigured], dir: File, log: Logger): Unit = {
     val jjrules = rules flatMap { r => r.rule match {
       case Rename(patterns @ _*) =>
         patterns.map { case (from, to) =>
@@ -84,11 +84,17 @@ private[sbtassembly] object Shader {
       entry.name = f._2
       entry.time = -1
 
-      proc.process(entry)
+      if (proc.process(entry)) {
+        IO.write(dir / entry.name, entry.data)
+      } else {
+        IO.delete(f._1)
+      }
 
-      IO.write(dir / entry.name, entry.data)
-      if (f._2 != entry.name) IO.delete(f._1)
     }
+
+    val excludes = proc.getExcludes()
+    excludes.foreach(exclude => IO.delete(dir / exclude))
+
   }
 
 }

--- a/src/main/scala/sbtassembly/Shader.scala
+++ b/src/main/scala/sbtassembly/Shader.scala
@@ -1,0 +1,93 @@
+package sbtassembly
+
+import java.io.File
+
+import org.pantsbuild.jarjar.ext_util.EntryStruct
+import org.pantsbuild.jarjar.{JJProcessor, Keep, Zap, Rule}
+
+import sbt._
+
+object Shader {
+
+  def rename(patterns: (String, String)*): ShadeRule =
+    ShadeRule(rule = "rename", renames = patterns.toMap)
+
+  def remove(patterns: String*): ShadeRule =
+    ShadeRule(rule = "remove", patterns = patterns.toSet)
+
+  def keepOnly(patterns: String*): ShadeRule =
+    ShadeRule(rule = "keepOnly", patterns = patterns.toSet)
+
+  private[sbtassembly] def shadeDirectory(rules: Seq[ShadeRule], dir: File, log: Logger): Unit = {
+    val jjrules = rules flatMap { r => r.rule match {
+      case "rename" =>
+        r.renames.map { case (from, to) =>
+          val jrule = new Rule()
+          jrule.setPattern(from)
+          jrule.setResult(to)
+          jrule
+        }
+      case "remove" =>
+        r.patterns.map { case pattern =>
+          val jrule = new Zap()
+          jrule.setPattern(pattern)
+          jrule
+        }
+      case "keepOnly" =>
+        r.patterns.map { case pattern =>
+          val jrule = new Keep()
+          jrule.setPattern(pattern)
+          jrule
+        }
+      case _ => Nil
+    }}
+
+    val proc = JJProcessor(jjrules, true, true)
+    val files = AssemblyUtils.getMappings(dir, Set())
+
+    val entry = new EntryStruct
+    files filter (!_._1.isDirectory) foreach { f =>
+      entry.data = IO.readBytes(f._1)
+      entry.name = f._2
+      entry.time = -1
+
+      proc.process(entry)
+
+      IO.write(dir / entry.name, entry.data)
+      if (f._2 != entry.name) IO.delete(f._1)
+    }
+  }
+
+}
+
+case class ShadeTarget(toCompiling: Boolean = false,
+                       group: Option[String] = None,
+                       artifact: Option[String] = None,
+                       version: Option[String] = None) {
+  private[sbtassembly] def isApplicableTo(mod: ModuleID): Boolean =
+    group.isDefined && group.get == mod.organization &&
+      artifact.isDefined && artifact.get == mod.name &&
+      (version.isEmpty || version.get == mod.revision)
+}
+
+case class ShadeRule(rule: String,
+                     renames: Map[String, String] = Map(),
+                     patterns: Set[String] = Set(),
+                     targets: Seq[ShadeTarget] = Seq()) {
+
+  def applyToCompiling: ShadeRule =
+    this.copy(targets = targets :+ ShadeTarget(true))
+
+  def applyTo(group: String, artifact: String): ShadeRule =
+    this.copy(targets = targets :+ ShadeTarget(group = Some(group), artifact = Some(artifact)))
+
+  def applyTo(group: String, artifact: String, version: String): ShadeRule =
+    this.copy(targets = targets :+ ShadeTarget(group = Some(group), artifact = Some(artifact), version = Some(version)))
+
+  private[sbtassembly] def isApplicableTo(mod: ModuleID): Boolean =
+    targets.exists(_.isApplicableTo(mod))
+
+  private[sbtassembly] def isApplicableToCompiling: Boolean =
+    targets.exists(_.toCompiling)
+
+}

--- a/src/sbt-test/shading/keeponly/build.sbt
+++ b/src/sbt-test/shading/keeponly/build.sbt
@@ -1,0 +1,23 @@
+lazy val testkeep = (project in file(".")).
+  settings(
+    version := "0.1",
+    assemblyJarName in assembly := "foo.jar",
+    scalaVersion := "2.9.1",
+    assemblyShadingRules in assembly := Seq(
+      ShadeRule.KeepOnly("keep.**").applyToCompiling
+    ),
+    TaskKey[Unit]("check") <<= (crossTarget) map { (crossTarget) ⇒
+      IO.withTemporaryDirectory { dir ⇒
+        IO.unzip(crossTarget / "foo.jar", dir)
+        mustNotExist(dir / "removed" / "ShadeClass.class")
+        mustNotExist(dir / "removed" / "ShadePackage.class")
+        mustExist(dir / "keep" / "Keeped.class")
+      }
+    })
+
+def mustNotExist(f: File): Unit = {
+  if (f.exists) sys.error("file" + f + " exists!")
+}
+def mustExist(f: File): Unit = {
+  if (!f.exists) sys.error("file" + f + " does not exist!")
+}

--- a/src/sbt-test/shading/keeponly/project/plugins.sbt
+++ b/src/sbt-test/shading/keeponly/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.eed3si9n" % "sbt-assembly" % pluginVersion)
+}

--- a/src/sbt-test/shading/keeponly/src/main/scala/keep/Keeped.scala
+++ b/src/sbt-test/shading/keeponly/src/main/scala/keep/Keeped.scala
@@ -1,0 +1,3 @@
+package keep
+
+class Keeped

--- a/src/sbt-test/shading/keeponly/src/main/scala/removed/ShadeClass.scala
+++ b/src/sbt-test/shading/keeponly/src/main/scala/removed/ShadeClass.scala
@@ -1,0 +1,3 @@
+package removed
+
+class ShadeClass

--- a/src/sbt-test/shading/keeponly/src/main/scala/removed/ShadePackage.scala
+++ b/src/sbt-test/shading/keeponly/src/main/scala/removed/ShadePackage.scala
@@ -1,0 +1,3 @@
+package removed
+
+class ShadePackage

--- a/src/sbt-test/shading/keeponly/test
+++ b/src/sbt-test/shading/keeponly/test
@@ -1,0 +1,6 @@
+# check if the file gets created
+> assembly
+$ exists target/scala-2.9.1/foo.jar
+
+# check if it says hello
+> check

--- a/src/sbt-test/shading/shading/build.sbt
+++ b/src/sbt-test/shading/shading/build.sbt
@@ -1,0 +1,25 @@
+lazy val testshade = (project in file(".")).
+  settings(
+    version := "0.1",
+    assemblyJarName in assembly := "foo.jar",
+    scalaVersion := "2.9.1",
+    assemblyShadingRules in assembly := Seq(
+      ShadeRule.Remove("remove.*").applyToCompiling,
+      ShadeRule.Rename("toshade.ShadeClass" -> "toshade.ShadedClass").applyToCompiling,
+      ShadeRule.Rename("toshade.ShadePackage" -> "shaded_package.ShadePackage").applyToCompiling
+    ),
+    TaskKey[Unit]("check") <<= (crossTarget) map { (crossTarget) ⇒
+      IO.withTemporaryDirectory { dir ⇒
+        IO.unzip(crossTarget / "foo.jar", dir)
+        mustNotExist(dir / "remove" / "Removed.class")
+        mustExist(dir / "shaded_package" / "ShadePackage.class")
+        mustExist(dir / "toshade" / "ShadedClass.class")
+      }
+    })
+
+def mustNotExist(f: File): Unit = {
+  if (f.exists) sys.error("file" + f + " exists!")
+}
+def mustExist(f: File): Unit = {
+  if (!f.exists) sys.error("file" + f + " does not exist!")
+}

--- a/src/sbt-test/shading/shading/project/plugins.sbt
+++ b/src/sbt-test/shading/shading/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.eed3si9n" % "sbt-assembly" % pluginVersion)
+}

--- a/src/sbt-test/shading/shading/src/main/scala/remove/Removed.scala
+++ b/src/sbt-test/shading/shading/src/main/scala/remove/Removed.scala
@@ -1,0 +1,3 @@
+package remove
+
+class Removed

--- a/src/sbt-test/shading/shading/src/main/scala/toshade/ShadeClass.scala
+++ b/src/sbt-test/shading/shading/src/main/scala/toshade/ShadeClass.scala
@@ -1,0 +1,3 @@
+package toshade
+
+class ShadeClass

--- a/src/sbt-test/shading/shading/src/main/scala/toshade/ShadePackage.scala
+++ b/src/sbt-test/shading/shading/src/main/scala/toshade/ShadePackage.scala
@@ -1,0 +1,3 @@
+package toshade
+
+class ShadePackage

--- a/src/sbt-test/shading/shading/test
+++ b/src/sbt-test/shading/shading/test
@@ -1,0 +1,6 @@
+# check if the file gets created
+> assembly
+$ exists target/scala-2.9.1/foo.jar
+
+# check if it says hello
+> check


### PR DESCRIPTION
Add shading support, #156.
In this PR, a new assembly setting key is introduced, namely `assemblyShadingRules`  
e.g.
```scala
assemblyShadingRules in assembly := Seq(
  Shader.rename("com.google.protobuf.**" -> "com.google.protobuf3.@1")
    .applyToCompiling
    .applyTo("com.google.protobuf", "protobuf-java", "3.0.0-alpha-3.1")
)
```
`assemblyShadingRules` consists of a sequence of shading rules. And there're three types of shading rules in total, they're: `Shader.rename`, `Shader.remove`, `Shader.keepOnly`. For each shading rule, it can be applied to a list of targets: `applyToCompiling` means applying it to current module, and `applyTo` means applying it to some dependency artifact.

These three types of shading rules originated from jarjar rules, for details please go to this [link](https://code.google.com/p/jarjar/wiki/CommandLineDocs).

