### PR TITLE
Add import for defaultShellScript to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ addArtifact(artifact in (Compile, assembly), assembly)
 You can prepend shell script to the fat jar as follows:
 
 ```scala
+import sbtassembly.AssemblyPlugin.defaultShellScript
+
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(prependShellScript = Some(defaultShellScript))
 
 assemblyJarName in assembly := s"${name.value}-${version.value}"


### PR DESCRIPTION
Resolves #153

On SBT 0.13.7 I get this error without the import
```
assemblyOption in assembly := (assemblyOption in assembly).value.copy(prependShellScript = Some(defaultShellScript))
                                                                                                ^
[error] Type error in expression
```