### PR TITLE
Fix assembly of projects containing spring-web

### DIFF
--- a/src/main/scala/sbtassembly/MergeStrategy.scala
+++ b/src/main/scala/sbtassembly/MergeStrategy.scala
@@ -145,7 +145,7 @@ object MergeStrategy {
           MergeStrategy.discard
         case "services" :: xs =>
           MergeStrategy.filterDistinctLines
-        case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) =>
+        case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) | ("spring.tooling" :: Nil) =>
           MergeStrategy.filterDistinctLines
         case _ => MergeStrategy.deduplicate
       }


### PR DESCRIPTION
If you have a project depending on spring-web

```
// build.sbt
libraryDependencies += "org.springframework" % "spring-web" % "4.2.1.RELEASE"
```

When you run `sbt assembly` I get

```
$HOME/.ivy2/cache/org.springframework/spring-aop/jars/spring-aop-4.2.1.RELEASE.jar:META-INF/spring.tooling
$HOME/.ivy2/cache/org.springframework/spring-beans/jars/spring-beans-4.2.1.RELEASE.jar:META-INF/spring.tooling
$HOME/.ivy2/cache/org.springframework/spring-context/jars/spring-context-4.2.1.RELEASE.jar:META-INF/spring.tooling
```

This pull request choose filterDistinctLines strategy for META-INF/spring.tooling files, fixing the problem.