### PR TITLE
Fixes https://github.com/sbt/sbt-assembly/issues/172 …

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file(".")).
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024"),
     libraryDependencies ++= Seq(
       "org.scalactic" %% "scalactic" % "2.2.1",
-      "org.pantsbuild.jarjar" % "jarjar" % "1.5"
+      "org.pantsbuild" % "jarjar" % "1.6.0"
     ),
     publishArtifact in (Compile, packageBin) := true,
     publishArtifact in (Test, packageBin) := false,

--- a/src/main/scala/org/pantsbuild/jarjar/JJProcessor.scala
+++ b/src/main/scala/org/pantsbuild/jarjar/JJProcessor.scala
@@ -1,6 +1,6 @@
 package org.pantsbuild.jarjar
 
-import org.pantsbuild.jarjar.ext_util.{EntryStruct, JarProcessor}
+import org.pantsbuild.jarjar.util.{EntryStruct, JarProcessor}
 
 import scala.collection.JavaConverters._
 

--- a/src/main/scala/sbtassembly/Shader.scala
+++ b/src/main/scala/sbtassembly/Shader.scala
@@ -2,8 +2,8 @@ package sbtassembly
 
 import java.io.File
 
-import org.pantsbuild.jarjar.ext_util.EntryStruct
 import org.pantsbuild.jarjar._
+import org.pantsbuild.jarjar.util.EntryStruct
 
 import sbt._
 


### PR DESCRIPTION
by updating to version 1.6.0 of jarjar

Prior to 1.6.0, jarjar did not support Java 8.  This caused shading rules to ignore all transitive dependencies of Java 8 code.  This is the most likely cause of #172.  