### PR TITLE
Shade directories after they've been copied

### DIFF
--- a/src/sbt-test/shading/directories/build.sbt
+++ b/src/sbt-test/shading/directories/build.sbt
@@ -1,0 +1,17 @@
+crossPaths := false
+
+assemblyJarName in assembly := "assembly.jar"
+
+assemblyShadeRules in assembly := Seq(
+  ShadeRule.rename("somepackage.**" -> "shaded.@1").inAll
+)
+
+TaskKey[Unit]("check") := {
+  val expected = "Hello shaded.SomeClass"
+  val output = Process("java", Seq("-jar", assembly.value.absString)).!!.trim
+  if (output != expected) sys.error("Unexpected output: " + output)
+}
+
+TaskKey[Unit]("unzip") := {
+  IO.unzip((assemblyOutputPath in assembly).value, crossTarget.value / "unzipped")
+}

--- a/src/sbt-test/shading/directories/project/plugins.sbt
+++ b/src/sbt-test/shading/directories/project/plugins.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % sys.props.getOrElse("plugin.version",
+  throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+))

--- a/src/sbt-test/shading/directories/src/main/scala/run/Hello.scala
+++ b/src/sbt-test/shading/directories/src/main/scala/run/Hello.scala
@@ -1,0 +1,8 @@
+package run
+
+object Hello {
+  def main(args: Array[String]): Unit = {
+    val name = (new somepackage.SomeClass).getClass.getName
+    println("Hello " + name)
+  }
+}

--- a/src/sbt-test/shading/directories/src/main/scala/somepackage/SomeClass.scala
+++ b/src/sbt-test/shading/directories/src/main/scala/somepackage/SomeClass.scala
@@ -1,0 +1,3 @@
+package somepackage
+
+class SomeClass

--- a/src/sbt-test/shading/directories/test
+++ b/src/sbt-test/shading/directories/test
@@ -1,0 +1,12 @@
+# Test that assembly contains shaded classes
+# but the original classes are left untouched.
+
+> check
+
+$ exists target/classes/somepackage/SomeClass.class
+$ absent target/classes/shaded/SomeClass.class
+
+> unzip
+
+$ exists target/unzipped/shaded/SomeClass.class
+$ absent target/unzipped/somepackage/SomeClass.class


### PR DESCRIPTION
Directories on the classpath are currently shaded in place – the original classes are deleted and renamed classes are added directly into the `target/classes` directory. This can break tests and other things which expect the original classes (for example, #172 looks related) and forces recompilation.

A workaround for inter-project dependencies is to use `exportJars := true`, as jar classes are copied before shading.

Fix this by only shading the copied classes, like for jars, and leave the original classes untouched.