### PR TITLE
Fix broken shading on Windows.

### DIFF
--- a/src/main/scala/sbtassembly/Shader.scala
+++ b/src/main/scala/sbtassembly/Shader.scala
@@ -81,7 +81,16 @@ private[sbtassembly] object Shader {
     }}
 
     val proc = JJProcessor(jjrules, verbose = level == Level.Debug, true)
-    val files = AssemblyUtils.getMappings(dir, Set())
+
+    /*
+    jarjar MisplacedClassProcessor class transforms byte[] to a class using org.objectweb.asm.ClassReader.getClassName
+    which always translates class names containing '.' into '/', regardless of OS platform.
+    We need to transform any windows file paths in order for jarjar to match them properly and not omit them.
+     */
+//    val files = AssemblyUtils.getMappings(dir, Set())
+
+    val files = AssemblyUtils.getMappings(dir, Set()).map(f =>
+      if (f._2.contains('\\')) (f._1, f._2.replace('\\', '/')) else f)
 
     val entry = new EntryStruct
     files filter (!_._1.isDirectory) foreach { f =>
@@ -96,5 +105,4 @@ private[sbtassembly] object Shader {
     val excludes = proc.getExcludes()
     excludes.foreach(exclude => IO.delete(dir / exclude))
   }
-
 }

--- a/src/main/scala/sbtassembly/Shader.scala
+++ b/src/main/scala/sbtassembly/Shader.scala
@@ -87,8 +87,6 @@ private[sbtassembly] object Shader {
     which always translates class names containing '.' into '/', regardless of OS platform.
     We need to transform any windows file paths in order for jarjar to match them properly and not omit them.
      */
-//    val files = AssemblyUtils.getMappings(dir, Set())
-
     val files = AssemblyUtils.getMappings(dir, Set()).map(f =>
       if (f._2.contains('\\')) (f._1, f._2.replace('\\', '/')) else f)
 


### PR DESCRIPTION
Attempting to use the shading functionality on Windows results in files being deleted from the uber JAR as a result of a naming mismatch of one of the `JarJar` processors called `MisplacedClassProcessor`.

Internally, `MisplacedClassProcessor.java` utilizes `org.objectweb.asm.ClassReader.getClassName` which replaces any '.' on the class name with '/' regardless of the underlying OS. This is documented:

> Returns the internal name of the class corresponding to this object or array type. The internal name of a class is its fully qualified name (as returned by Class.getName(), **where '.' are replaced by '/'.** This method should only be used for an object or array type.

All windows class names get translated using '\' instead of '.'. This causes `assemblyShadeRules` to *mismatch all classes*, causing them to be removed from the uber JAR.

This fix makes sure the class name uses '/' instead, for all class names regardless of the OS.