### PR TITLE
Add a general facility to tell if a module matches

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val commonSettings: Seq[Setting[_]] = Seq(
-  git.baseVersion in ThisBuild := "0.14.3",
+  git.baseVersion in ThisBuild := "0.15.0",
   organization in ThisBuild := "com.eed3si9n"
 )
 

--- a/src/main/scala/sbtassembly/Shader.scala
+++ b/src/main/scala/sbtassembly/Shader.scala
@@ -13,7 +13,7 @@ case class ShadeRule(shadePattern: ShadePattern, targets: Seq[ShadeTarget] = Seq
     this.copy(targets = targets :+ ShadeTarget(inAll = true))
   def inProject: ShadeRule =
     this.copy(targets = targets :+ ShadeTarget(inProject = true))
-  def matches(predicate: ModuleID => Boolean): ShadeRule =
+  def ifMatches(predicate: ModuleID => Boolean): ShadeRule =
     this.copy(targets = targets :+ MatchingShadeTarget(predicate))
 
   private[sbtassembly] def isApplicableTo(mod: ModuleID): Boolean =
@@ -31,7 +31,7 @@ sealed trait ShadePattern {
     ShadeRule(this, Seq(ShadeTarget(inAll = true)))
   def inProject: ShadeRule =
     ShadeRule(this, Seq(ShadeTarget(inProject = true)))
-  def matches(predicate: ModuleID => Boolean): ShadeRule =
+  def ifMatches(predicate: ModuleID => Boolean): ShadeRule =
     ShadeRule(this, Seq(MatchingShadeTarget(predicate)))
 }
 


### PR DESCRIPTION
Several places I've come across in the maven world do things like filter all modules matching a given organization - this could be easily implemented here via something like 


```
    ShadeRule.zap("*").ifMatches(moduleID => moduleID.organization.equals("foo.bar"))
```