### PR TITLE
Dependencies update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,10 @@ lazy val root = (project in file(".")).
     licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-assembly/blob/master/LICENSE")),
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024"),
     libraryDependencies ++= Seq(
-      "org.scalactic" %% "scalactic" % "2.2.6",
-      "org.pantsbuild" % "jarjar" % "1.6.2"
+      "org.scalactic" %% "scalactic" % "3.0.1",
+      "org.pantsbuild" % "jarjar" % "1.6.3" excludeAll ExclusionRule("org.ow2.asm"),
+      "org.ow2.asm" % "asm" % "5.2",
+      "org.ow2.asm" % "asm-commons" % "5.2"
     ),
     publishArtifact in (Compile, packageBin) := true,
     publishArtifact in (Test, packageBin) := false,


### PR DESCRIPTION
Fixes #205

The most important is asm dep update. As `jarjar 1.6.x` depends on `asm 5.0.4`, which contains bug https://github.com/sbt/sbt-assembly/issues/205#issuecomment-279964607 (thx @karol-brejna-i  for pointing to that).