### PR TITLE
Add AssemblyOption to limit the generated hash length

### DIFF
--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -56,6 +56,7 @@ object AssemblyPlugin extends sbt.AutoPlugin {
         cacheUnzip         = true,
         appendContentHash  = false,
         prependShellScript = None,
+        maxHashLength      = None,
         shadeRules         = (assemblyShadeRules in assembly).value,
         level              = (logLevel in assembly).value)
     },
@@ -116,5 +117,6 @@ case class AssemblyOption(assemblyDirectory: File,
   cacheUnzip: Boolean = true,
   appendContentHash: Boolean = false,
   prependShellScript: Option[Seq[String]] = None,
+  maxHashLength: Option[Int] = None,
   shadeRules: Seq[ShadeRule] = Seq(),
   level: Level.Value)


### PR DESCRIPTION
Sometime the generated path for assembly classes can cause "File name too long" exceptions (as described in Issue #69 ). While this is originated by encrypted HOME folder - it's possible to limit the generated hash part of the path to reduce some of these cases.

This PR added `maxHashLength` option to `AssemblyOption` to restrict the generated hash part length.