### PR TITLE
Fix to #266 use method withClassifier compatible with both old and new sbt version

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ and all of the other artifacts, add an `assembly` classifier (or other):
 ```scala
 artifact in (Compile, assembly) := {
   val art = (artifact in (Compile, assembly)).value
-  art.copy(`classifier` = Some("assembly"))
+  art.withClassifier(Some("assembly"))
 }
 
 addArtifact(artifact in (Compile, assembly), assembly)


### PR DESCRIPTION
Fix to documentation. Using the method `withClassifier` is preferred because both old version and new version (up to 1.0.2) of sbt support the method `withClassifier`.