### PR TITLE
application.conf should be concatenated just like reference.conf

### DIFF
--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -278,7 +278,7 @@ object Assembly {
 
   def isConfigFile(fileName: String): Boolean =
     fileName.toLowerCase match {
-      case "reference.conf" | "rootdoc.txt" | "play.plugins" => true
+      case "reference.conf" | "application.conf" | "rootdoc.txt" | "play.plugins" => true
       case _ => false
     }
 


### PR DESCRIPTION
https://github.com/lightbend/config/blob/master/README.md#standard-behavior says it will load "application.conf (all resources on classpath with this name)." Thus while running in sbt you can have application.conf in several modules, but sbt-assembly will choke if it's combining them.