### PR TITLE
Upgrade JarJar to 1.6.5 for better Java 9 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file(".")).
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024"),
     libraryDependencies ++= Seq(
       "org.scalactic" %% "scalactic" % "3.0.1",
-      "org.pantsbuild" % "jarjar" % "1.6.4"
+      "org.pantsbuild" % "jarjar" % "1.6.5"
     ),
     publishArtifact in (Compile, packageBin) := true,
     publishArtifact in (Test, packageBin) := false,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16-M1
+sbt.version=0.13.16


### PR DESCRIPTION
Needed to be able to shade some jars that contain Java 9 module info.