### PR TITLE
disabled shebang in universal script by default...

### DIFF
--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -25,7 +25,7 @@ object AssemblyPlugin extends sbt.AutoPlugin {
 
   private def universalScript(shellCommands: String,
                               cmdCommands: String,
-                              shebang: Boolean = false): String = {
+                              shebang: Boolean): String = {
     Seq(
       if (shebang) "#!/usr/bin/env sh" else "",
       "@ 2>/dev/null # 2>nul & echo off & goto BOF\r",
@@ -42,7 +42,7 @@ object AssemblyPlugin extends sbt.AutoPlugin {
     ).filterNot(_.isEmpty).mkString("\n")
   }
 
-  def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = false): Seq[String] = {
+  def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = true): Seq[String] = {
     val javaOptsString = javaOpts.map(_ + " ").mkString
     Seq(universalScript(
       shellCommands = s"""exec java -jar $javaOptsString$$JAVA_OPTS "$$0" "$$@"""",

--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -35,7 +35,6 @@ object AssemblyPlugin extends sbt.AutoPlugin {
       Seq(
         "",
         ":BOF",
-        "@echo off",
         cmdCommands.replaceAll("\r\n|\n", "\r\n"),
         "exit /B %errorlevel%",
         ""
@@ -43,7 +42,7 @@ object AssemblyPlugin extends sbt.AutoPlugin {
     ).filterNot(_.isEmpty).mkString("\n")
   }
 
-  def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = true): Seq[String] = {
+  def defaultUniversalScript(javaOpts: Seq[String] = Seq.empty, shebang: Boolean = false): Seq[String] = {
     val javaOptsString = javaOpts.map(_ + " ").mkString
     Seq(universalScript(
       shellCommands = s"""exec java -jar $javaOptsString$$JAVA_OPTS "$$0" "$$@"""",


### PR DESCRIPTION
... and removed redundant "@echo off"

In this pr I changed the shebang to be disabled by default because it produces an unexpected error on Windows (this is already documented in the readme) and it is easy to add on Linux or can be enabled manually.