### PR TITLE
Add support for merging reference-overrides.conf as config

### DIFF
--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -46,7 +46,7 @@ object Assembly {
 
         Using.fileOutputStream(true)(outPath) { out => IO.transfer(tmpFile, out) }
         tmpFile.delete()
-        
+
         try {
           sys.process.Process("chmod", Seq("+x", outPath.toString)).!
         }
@@ -274,7 +274,7 @@ object Assembly {
 
   def isConfigFile(fileName: String): Boolean =
     fileName.toLowerCase match {
-      case "reference.conf" | "application.conf" | "rootdoc.txt" | "play.plugins" => true
+      case "reference.conf" | "reference-overrides.conf" | "application.conf" | "rootdoc.txt" | "play.plugins" => true
       case _ => false
     }
 


### PR DESCRIPTION
Multiple jars include `reference-overrides.conf` configuration files that the default settings in `sbt assembly` fail to merge since they are not treated as configuration files. I've added the file to the known configuration files so that the user doesn't have to manually add merge config for those.