### PR TITLE
Update jarjar to 1.6.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file(".")).
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024", "-Xfuture"),
     libraryDependencies ++= Seq(
       "org.scalactic" %% "scalactic" % "3.0.1",
-      "org.pantsbuild" % "jarjar" % "1.6.5"
+      "org.pantsbuild" % "jarjar" % "1.6.6"
     ),
     TaskKey[Unit]("runScriptedTest") := Def.taskDyn {
       val sbtBinVersion = (sbtBinaryVersion in pluginCrossBuild).value


### PR DESCRIPTION
`jarjar` 1.6.6 is available.

References

- https://github.com/pantsbuild/jarjar/pull/35
- http://search.maven.org/#artifactdetails%7Corg.pantsbuild%7Cjarjar%7C1.6.6%7Cjar

Between the changes, there is one that allows strings with dashes to be [modified when shading](https://github.com/pantsbuild/jarjar/pull/35/files#diff-b9e9a686c23769a252af07dccfd3141bR37).