### PR TITLE
fix(248): Shading randomly fails.

### DIFF
--- a/src/main/scala/sbtassembly/Shader.scala
+++ b/src/main/scala/sbtassembly/Shader.scala
@@ -98,6 +98,7 @@ private[sbtassembly] object Shader {
       entry.data = IO.readBytes(f._1)
       entry.name = f._2
       entry.time = -1
+      entry.skipTransform = false
       IO.delete(f._1)
       if (proc.process(entry)) {
         IO.write(dir / entry.name, entry.data)


### PR DESCRIPTION
Fixed an issue to the Shader class that caused shading rules to fail being applied correctly. The issues looked random and behavior was different from one machine to the other. The issue was trigged when we started shading Multi-Release jars that contained classes files under META-INF.

The issue is from the reuse the EntryStruct from one call to the other. Once the flag skipTransform is set to true (By jarjar's MisplacedClassProcessor), the plugin stop applying the shading rule. The behavior looks random since it is affected by the order in which the files are processed.

The patch just make sure to reset the flag between each call.