### PR TITLE
Fix #381: Change trigger to noTrigger

### DIFF
--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -5,7 +5,7 @@ import Keys._
 
 object AssemblyPlugin extends sbt.AutoPlugin {
   override def requires = plugins.JvmPlugin
-  override def trigger = allRequirements
+  override def trigger = noTrigger
 
   object autoImport extends AssemblyKeys {
     val Assembly = sbtassembly.Assembly


### PR DESCRIPTION
Fat jars are normally built for specific projects: executable ones. So
having the plugin trigger for all projects doesn't make sense. Changes
the trigger to noTrigger.