### PR TITLE
Cater for Scala 2.13 and includeScala=false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ project/plugins/lib_managed
 project/plugins/src_managed
 project/plugins/target
 project/plugins/project/build.properties
+.idea

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -11,6 +11,22 @@ import PluginCompat._
 object Assembly {
   import AssemblyPlugin.autoImport.{ Assembly => _, _ }
 
+  private val scalaPre213Libraries = Vector(
+    "scala-actors",
+    "scala-compiler",
+    "scala-continuations",
+    "scala-library",
+    "scala-parser-combinators",
+    "scala-reflect",
+    "scala-swing",
+    "scala-xml")
+  private val scala213AndLaterLibraries = Vector(
+    "scala-actors",
+    "scala-compiler",
+    "scala-continuations",
+    "scala-library",
+    "scala-reflect")
+
   val defaultExcludedFiles: Seq[File] => Seq[File] = (base: Seq[File]) => Nil
 
   def apply(out0: File, ao: AssemblyOption, po: Seq[PackageOption], mappings: Seq[MappingSet],
@@ -169,15 +185,12 @@ object Assembly {
 
     val depLibs      = dependencies.map(_.data).toSet.filter(ClasspathUtilities.isArchive)
     val excludedJars = ao.excludedJars map {_.data}
-    val libsFiltered = (libs flatMap {
+    val libsFiltered = libs flatMap {
       case jar if excludedJars contains jar.data.asFile => None
-      case jar if isScalaLibraryFile(jar.data.asFile) =>
-        if (ao.includeScala) Some(jar) else None
-      case jar if depLibs contains jar.data.asFile =>
-        if (ao.includeDependency) Some(jar) else None
-      case jar =>
-        if (ao.includeBin) Some(jar) else None
-    })
+      case jar if ao.includeScala && isScalaLibraryFile(ao, jar.data.asFile) => Some(jar)
+      case jar if ao.includeDependency && depLibs.contains(jar.data.asFile) => Some(jar)
+      case jar => if (ao.includeBin) Some(jar) else None
+    }
     val dirRules = shadeRules.filter(_.isApplicableToCompiling)
     val dirsFiltered =
       dirs.par flatMap {
@@ -278,17 +291,10 @@ object Assembly {
       case _ => false
     }
 
-  def isScalaLibraryFile(file: File): Boolean =
-    Vector("scala-actors",
-      "scala-compiler",
-      "scala-continuations",
-      "scala-library",
-      "scala-parser-combinators",
-      "scala-reflect",
-      "scala-swing",
-      "scala-xml") exists { x =>
-      file.getName startsWith x
-    }
+  def isScalaLibraryFile(ao: AssemblyOption, file: File): Boolean = {
+    val scalaLibraries = if (ao.isScala213AndLater) scala213AndLaterLibraries else scalaPre213Libraries
+    scalaLibraries exists { x => file.getName startsWith x }
+  }
 
   private[sbtassembly] def sha1 = MessageDigest.getInstance("SHA-1")
   private[sbtassembly] def sha1content(f: File): String = {

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -187,9 +187,12 @@ object Assembly {
     val excludedJars = ao.excludedJars map {_.data}
     val libsFiltered = libs flatMap {
       case jar if excludedJars contains jar.data.asFile => None
-      case jar if ao.includeScala && isScalaLibraryFile(ao, jar.data.asFile) => Some(jar)
-      case jar if ao.includeDependency && depLibs.contains(jar.data.asFile) => Some(jar)
-      case jar => if (ao.includeBin) Some(jar) else None
+      case jar if isScalaLibraryFile(ao, jar.data.asFile) =>
+        if (ao.includeScala) Some(jar) else None
+      case jar if depLibs contains jar.data.asFile =>
+        if (ao.includeDependency) Some(jar) else None
+      case jar =>
+        if (ao.includeBin) Some(jar) else None
     }
     val dirRules = shadeRules.filter(_.isApplicableToCompiling)
     val dirsFiltered =

--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -90,7 +90,11 @@ object AssemblyPlugin extends sbt.AutoPlugin {
         prependShellScript = None,
         maxHashLength      = None,
         shadeRules         = (assemblyShadeRules in assembly).value,
-        level              = (logLevel in assembly).value)
+        level              = (logLevel in assembly).value,
+        isScala213AndLater = {
+          val version = VersionNumber(scalaVersion.value)
+          version.numbers.length>=2 && version._1.get>=2 && version._2.get>=13
+        })
     },
 
     assemblyOption in assemblyPackageScala := {
@@ -151,4 +155,5 @@ case class AssemblyOption(assemblyDirectory: File,
   prependShellScript: Option[Seq[String]] = None,
   maxHashLength: Option[Int] = None,
   shadeRules: Seq[ShadeRule] = Seq(),
-  level: Level.Value)
+  level: Level.Value,
+  isScala213AndLater: Boolean = false)

--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -90,11 +90,8 @@ object AssemblyPlugin extends sbt.AutoPlugin {
         prependShellScript = None,
         maxHashLength      = None,
         shadeRules         = (assemblyShadeRules in assembly).value,
-        level              = (logLevel in assembly).value,
-        isScala213AndLater = {
-          val version = VersionNumber(scalaVersion.value)
-          version.numbers.length>=2 && version._1.get>=2 && version._2.get>=13
-        })
+        scalaVersion       = scalaVersion.value,
+        level              = (logLevel in assembly).value)
     },
 
     assemblyOption in assemblyPackageScala := {
@@ -155,5 +152,5 @@ case class AssemblyOption(assemblyDirectory: File,
   prependShellScript: Option[Seq[String]] = None,
   maxHashLength: Option[Int] = None,
   shadeRules: Seq[ShadeRule] = Seq(),
-  level: Level.Value,
-  isScala213AndLater: Boolean = false)
+  scalaVersion: String = "",
+  level: Level.Value)


### PR DESCRIPTION
Fixes #380

The Scala 2.13 distribution does not include scala-xml and a few other jars. If includeScala=false and you need to include scala-xml, the function Assembly.isScalaLibraryFile needs to cater for a reduced set of libraries.