### PR TITLE
Add homepage setting to build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "sbt-assembly",
     description := "sbt plugin to create a single fat jar",
+    homepage := Some(url("https://github.com/sbt/sbt-assembly")),
     licenses := Seq("MIT License" -> url("https://github.com/sbt/sbt-assembly/blob/master/LICENSE")),
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024", "-Xfuture"),
     libraryDependencies ++= Seq(


### PR DESCRIPTION
This enables Scala Steward to link to this page, the GitHub release notes
and version diff in its pull requests.