### PR TITLE
Update jarjar-abrams to 0.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024", "-Xfuture")
     libraryDependencies ++= Seq(
       "org.scalactic" %% "scalactic" % "3.0.8",
-      "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "0.1.0",
+      "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "0.3.1",
       "org.scalatest" %% "scalatest" % "3.1.1" % Test,
     )
     (pluginCrossBuild / sbtVersion) := {


### PR DESCRIPTION
The bug fixed in jarjar-abrams 0.3.1 from PR: https://github.com/eed3si9n/jarjar-abrams/pull/10 is preventing us from upgrading sbt-assembly 0.14.9 to 0.15.0

I don't have knowledge of the codebases, so I am expecting CI to make sure that the update is safe.