### PR TITLE
Fixes "Negative Time" issue

### DIFF
--- a/src/main/scala/sbtassembly/AssemblyUtils.scala
+++ b/src/main/scala/sbtassembly/AssemblyUtils.scala
@@ -59,7 +59,7 @@ object AssemblyUtils {
           //log.debug("Extracting zip entry '" + name + "' to '" + target + "'")
 
           try {
-            if(entry.isDirectory)
+            if (entry.isDirectory)
               IO.createDirectory(target)
             else
             {
@@ -68,8 +68,14 @@ object AssemblyUtils {
                 fileOutputStream(false)(target) { out => IO.transfer(from, out) }
               }
             }
-            if(preserveLastModified)
-              target.setLastModified(entry.getTime)
+
+            if (preserveLastModified) {
+              val t: Long = entry.getTime
+              val EPOCH_1980_01_01 = 315532800000L
+              val EPOCH_2010_01_01 = 1262304000000L
+              if (t > EPOCH_1980_01_01) target.setLastModified(t)
+              else target.setLastModified(EPOCH_2010_01_01)
+            }
           } catch {
             case e: Throwable => log.warn(e.getMessage)
           }


### PR DESCRIPTION
sbt 1.4.0 started wiping the timestamp in the JAR file to 1970-01-01
even though some file system including the DOS timestamp used by ZIP
files are unable to handle file stamp before 1980.
Until this was fixed in sbt 1.4.8, we now have JAR files out in the wild
with 1970-01-01 timestamp.

On the other side, JDK 11 started adding stricter check on this and
started throwing exception "Negative Time" when it thinks the timestamp
is about to be set to something below 1970-01-01.
Maybe due to the timezone 1970-01-01 is actually interpreted to be
1969-12-31 or something. I'm not sure.
But basically the fix is to use some other timestamp when it's before
1980 and that should be ok with JDK 11's 1970-01-01 check.

Fixes #410