### PR TITLE
Replace obsolete Bintray badge with Scaladex version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@ Setup
 
 ### Using Published Plugin
 
-![Bintray version](https://img.shields.io/bintray/v/eed3si9n/sbt-plugins/sbt-assembly.svg)
+[![sbt-assembly Scala version support](https://index.scala-lang.org/sbt/sbt-assembly/sbt-assembly/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/sbt/sbt-assembly/sbt-assembly)
 
 Add sbt-assembly as a dependency in `project/plugins.sbt`:
 
 ```scala
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "x.y.z")
 ```
-
-(You may need to check this project's tags to see what the most recent release is.)
 
 Usage
 -----


### PR DESCRIPTION
Unfortunately the Bintray badge on the readme just reads _'no longer available'_ these days:

![Bintray version](https://img.shields.io/bintray/v/eed3si9n/sbt-plugins/sbt-assembly.svg)

...I guess due to Bintray being [sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)? However, this new Scaladex badge can replace the old Bintray badge - it summarises which versions of sbt are supported by sbt-assembly (and what the latest sbt-assembly version is for each of those sbt versions):

[![sbt-assembly Scala version support](https://index.scala-lang.org/sbt/sbt-assembly/sbt-assembly/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/sbt/sbt-assembly/sbt-assembly)

More details on the badge format here: https://github.com/scalacenter/scaladex/pull/660 (with some extra changes to better support sbt in https://github.com/scalacenter/scaladex/pull/674).