### PR TITLE
Fix windows problems (#472)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / version := "2.0.0-SNAPSHOT"
+ThisBuild / version := "2.0.1-SNAPSHOT"
 ThisBuild / organization := "com.eed3si9n"
 
 def scala212 = "2.12.8"

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -36,7 +36,7 @@ object Assembly {
   type LazyInputStream = () => InputStream
 
   val defaultShadeRules: Seq[com.eed3si9n.jarjarabrams.ShadeRule] = Nil
-  val newLine: String = System.lineSeparator()
+  val newLine: String = "\n"
   val indent: String = " " * 2
   val newLineIndented: String = newLine + indent
 
@@ -530,7 +530,7 @@ object Assembly {
       manifest: JManifest,
       localTime: Long
   ): Unit = {
-    jarFileSystemResource(URI.create(s"jar:file:${output.toPath.toString}")) { jarFs =>
+    jarFileSystemResource(URI.create(s"jar:${output.toURI}")) { jarFs =>
       val manifestPath = jarFs.getPath("META-INF/MANIFEST.MF")
       Files.createDirectories(manifestPath.getParent)
       val manifestOut = Files.newOutputStream(
@@ -717,11 +717,12 @@ object Assembly {
 }
 
 object PathList {
-  private val sysFileSep = System.getProperty("file.separator")
+  private val sysFileSep = "/"
 
   def unapplySeq(path: String): Option[Seq[String]] = {
-    val split = path.split(if (sysFileSep.equals("""\""")) """\\""" else sysFileSep)
-    if (split.isEmpty) None
-    else Some(split.toList)
+    val sanitizedPath = if (path.contains('\\')) path.replace('\\', '/') else path
+    val split = sanitizedPath.split(sysFileSep)
+    if (split.isEmpty) Option.empty
+    else Option(split.toList)
   }
 }

--- a/src/main/scala/sbtassembly/AssemblyUtils.scala
+++ b/src/main/scala/sbtassembly/AssemblyUtils.scala
@@ -59,6 +59,6 @@ private[sbtassembly] object AssemblyUtils {
      * @param eof the terminating string to add at the end if needed
      * @return an [[AppendEofInputStream]] instance
      */
-    def apply(is: InputStream, eof: String = System.lineSeparator()) = new AppendEofInputStream(is, eof)
+    def apply(is: InputStream, eof: String = "\n") = new AppendEofInputStream(is, eof)
   }
 }

--- a/src/sbt-test/sbt-assembly/piecemeal/build.sbt
+++ b/src/sbt-test/sbt-assembly/piecemeal/build.sbt
@@ -24,7 +24,8 @@ lazy val root = (project in file("."))
     },
     TaskKey[Unit]("check2") := {
       val process = sys.process.Process("java", Seq("-cp",
-        (crossTarget.value / "scala-library-2.12.15-assembly.jar").toString + ":" +
+        (crossTarget.value / "scala-library-2.12.15-assembly.jar").toString +
+        (if (scala.util.Properties.isWin) ";" else ":") +
         (crossTarget.value / "foo-assembly-0.1.jar").toString,
         "Main"))
       val out = (process!!)


### PR DESCRIPTION
Based on Issue #472

Fixes for travis windows ci build

- `merging / merging` fails in both in both 1.x and 2.x because we use `System.getProperty(lineSeparator)` and that causes the file to be written with CRLF endings in Windows. It can be fixed by using just `\n`
- `sbt-assembly / piecemeal` fails in both in both 1.x and 2.x because of the wrong classpath syntax used by the jar runner in `src/sbt-test/sbt-assembly/piecemeal/build.sbt`. The separator for the classpath `java -cp` in Windows is `;` instead of `:`
- all other tests fail only in 2.x because of the error you reported in #472 
- There is another failure in 2.x, where we use `System.getProperty(file.separator)` for `PathList.unapply`, which we should not. We should just use `/` since every class file goes through the shader that converts all `\` to `/`.

**Note** [PR](https://github.com/sbt/sbt-assembly/pull/471) for including Windows in the Travis CI should be merged too