### PR TITLE
Fix handing of file separator in concat

### DIFF
--- a/src/main/scala/sbtassembly/AssemblyUtils.scala
+++ b/src/main/scala/sbtassembly/AssemblyUtils.scala
@@ -27,7 +27,10 @@ private[sbtassembly] object AssemblyUtils {
       readWithEnqueue(() => source.read(), enqueue)
 
     override def read(b: Array[Byte], off: Int, len: Int): Int =
-      readWithEnqueue(() => source.read(b, off, len), _ => b.map(_.toInt).foreach(enqueue))
+      readWithEnqueue(() => source.read(b, off, len), {
+        case -1 => ()
+        case bytesRead => b.slice(off, off + bytesRead).map(_.toInt).foreach(enqueue)
+      })
 
     override def close(): Unit = {
       is.close()

--- a/src/main/scala/sbtassembly/AssemblyUtils.scala
+++ b/src/main/scala/sbtassembly/AssemblyUtils.scala
@@ -29,7 +29,7 @@ private[sbtassembly] object AssemblyUtils {
     override def read(b: Array[Byte], off: Int, len: Int): Int =
       readWithEnqueue(() => source.read(b, off, len), {
         case -1 => ()
-        case bytesRead => b.slice(off, off + bytesRead).map(_.toInt).foreach(enqueue)
+        case bytesRead => (off until off + bytesRead).foreach(i => enqueue(b(i).toInt))
       })
 
     override def close(): Unit = {


### PR DESCRIPTION
Per [Java docs](https://docs.oracle.com/javase/8/docs/api/java/io/InputStream.html#read-byte:A-int-int-), `read(b, off, len)` returns the number of bytes read. So when enqueuing, you can't just enqueue the whole buffer. Only the slice of buffer between `off` and the number of bytes read.