### PR TITLE
feat: tag assembly task

### DIFF
--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -12,6 +12,7 @@ import sbt.util.FileInfo.lastModified
 import sbt.util.Tracked.{ inputChanged, lastOutput }
 import sbt.util.{ FilesInfo, Level, ModifiedFileInfo }
 import sbt.{ File, Logger, _ }
+import sbt.Tags.Tag
 import CacheImplicits._
 import sbtassembly.AssemblyPlugin.autoImport.{ Assembly => _, _ }
 import sbtassembly.PluginCompat.ClasspathUtilities
@@ -39,6 +40,8 @@ object Assembly {
   val newLine: String = "\n"
   val indent: String = " " * 2
   val newLineIndented: String = newLine + indent
+
+  val assemblyTag = Tag("assembly")
 
   private[sbtassembly] type CacheKey = FilesInfo[ModifiedFileInfo] :+:
     Map[String, (Boolean, String)] :+: // map of target paths that matched a merge strategy
@@ -192,7 +195,7 @@ object Assembly {
       s.cacheDirectory,
       s.log
     )
-  }
+  }.tag(assemblyTag)
 
   /**
    * Builds an assembly jar

--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -36,7 +36,8 @@ object AssemblyPlugin extends sbt.AutoPlugin {
     assemblyAppendContentHash := false,
     assemblyPrependShellScript := None,
     assemblyCacheOutput := true,
-    assemblyRepeatableBuild := true
+    assemblyRepeatableBuild := true,
+    concurrentRestrictions += Tags.limit(Assembly.assemblyTag, 1)
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = assemblySettings


### PR DESCRIPTION
Add a tag for the assembly tasks. This can be used to restrict resource usages.

**Why do we need this?**

Version 2 of sbt-assembly uses more resources. This is problematic when executing `assembly` on a multi-module project causing different types of errors. I've encountered memory and to many open files issue. Adding a tag gives the user of the plugin the option to restrict concurrent executions with `Global / concurrentRestrictions += Tags.limit(Assembly.assemblyTag, 1)`

**Things to consider**
- Should we reuse some of the existing tags? Sbt has defined both cpu, memory and disk tags.
- Should the plugin have a default limit on the tag? 