### PR TITLE
Support to convert cross-versioned ModuleID to ModuleCoordinate

### DIFF
--- a/src/main/contraband/AssemblyShadeRule.contra
+++ b/src/main/contraband/AssemblyShadeRule.contra
@@ -1,0 +1,28 @@
+package sbtassembly
+@target(Scala)
+
+type AssemblyShadeRule {
+  rule: com.eed3si9n.jarjarabrams.ShadeRule!
+  moduleIds: [sbt.librarymanagement.ModuleID]
+
+  #x def inAll: AssemblyShadeRule = this.withRule(rule.inAll)
+  #x def inProject: AssemblyShadeRule = this.withRule(rule.inProject)
+  #x def inModuleCoordinates(modules: com.eed3si9n.jarjarabrams.ModuleCoordinate*): AssemblyShadeRule =
+  #x   this.withRule(rule.inModuleCoordinates(modules: _*))
+  #x def inLibrary(modules: sbt.librarymanagement.ModuleID*): AssemblyShadeRule = this.withModuleIds(moduleIds ++ modules)
+
+  #x def toShadeRule(scalaVersion: String, scalaBinaryVersion: String): com.eed3si9n.jarjarabrams.ShadeRule =
+  #x   rule.inModuleCoordinates(
+  #x     moduleIds
+  #x       .map(sbt.librarymanagement.CrossVersion(scalaVersion, scalaBinaryVersion))
+  #x       .map(m => com.eed3si9n.jarjarabrams.ModuleCoordinate(m.organization, m.name, m.revision)): _*
+  #x   )
+
+  #xcompanion trait implicits {
+  #xcompanion   implicit def assemblyShadeRuleFromShareRule(rule: com.eed3si9n.jarjarabrams.ShadeRule): AssemblyShadeRule = AssemblyShadeRule(rule)
+  #xcompanion   implicit def assemblyShadeRuleFromShadePattern(pattern: com.eed3si9n.jarjarabrams.ShadePattern): AssemblyShadeRule = AssemblyShadeRule(pattern)
+  #xcompanion }
+
+  #xcompanion def apply(rule: com.eed3si9n.jarjarabrams.ShadeRule): AssemblyShadeRule = AssemblyShadeRule(rule, Vector.empty)
+  #xcompanion def apply(pattern: com.eed3si9n.jarjarabrams.ShadePattern): AssemblyShadeRule = AssemblyShadeRule(com.eed3si9n.jarjarabrams.ShadeRule(pattern, Vector.empty))
+}

--- a/src/main/scala/sbtassembly/AssemblyKeys.scala
+++ b/src/main/scala/sbtassembly/AssemblyKeys.scala
@@ -15,7 +15,7 @@ trait AssemblyKeys {
   lazy val assemblyOutputPath        = taskKey[File]("output path of the über jar")
   lazy val assemblyExcludedJars      = taskKey[Classpath]("list of excluded jars")
   lazy val assemblyMergeStrategy     = settingKey[String => MergeStrategy]("mapping from archive member path to merge strategy")
-  lazy val assemblyShadeRules        = settingKey[Seq[jarjarabrams.ShadeRule]]("shading rules backed by jarjar")
+  lazy val assemblyShadeRules        = settingKey[Seq[AssemblyShadeRule]]("shading rules backed by jarjar")
   lazy val assemblyAppendContentHash = settingKey[Boolean]("Appends SHA-1 fingerprint to the assembly file name")
   lazy val assemblyMaxHashLength     = settingKey[Int]("Length of SHA-1 fingerprint used for the assembly file name")
   lazy val assemblyCacheOutput       = settingKey[Boolean]("Enables (true) or disables (false) cacheing the output if the content has not changed")

--- a/src/main/scala/sbtassembly/AssemblyShadeRule.scala
+++ b/src/main/scala/sbtassembly/AssemblyShadeRule.scala
@@ -1,0 +1,51 @@
+/**
+ * This code is generated using [[https://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbtassembly
+final class AssemblyShadeRule private (
+  val rule: com.eed3si9n.jarjarabrams.ShadeRule,
+  val moduleIds: Vector[sbt.librarymanagement.ModuleID]) extends Serializable {
+  def inAll: AssemblyShadeRule = this.withRule(rule.inAll)
+  def inProject: AssemblyShadeRule = this.withRule(rule.inProject)
+  def inModuleCoordinates(modules: com.eed3si9n.jarjarabrams.ModuleCoordinate*): AssemblyShadeRule =
+  this.withRule(rule.inModuleCoordinates(modules: _*))
+  def inLibrary(modules: sbt.librarymanagement.ModuleID*): AssemblyShadeRule = this.withModuleIds(moduleIds ++ modules)
+  def toShadeRule(scalaVersion: String, scalaBinaryVersion: String): com.eed3si9n.jarjarabrams.ShadeRule =
+  rule.inModuleCoordinates(
+  moduleIds
+  .map(sbt.librarymanagement.CrossVersion(scalaVersion, scalaBinaryVersion))
+  .map(m => com.eed3si9n.jarjarabrams.ModuleCoordinate(m.organization, m.name, m.revision)): _*
+  )
+  
+  
+  override def equals(o: Any): Boolean = this.eq(o.asInstanceOf[AnyRef]) || (o match {
+    case x: AssemblyShadeRule => (this.rule == x.rule) && (this.moduleIds == x.moduleIds)
+    case _ => false
+  })
+  override def hashCode: Int = {
+    37 * (37 * (37 * (17 + "sbtassembly.AssemblyShadeRule".##) + rule.##) + moduleIds.##)
+  }
+  override def toString: String = {
+    "AssemblyShadeRule(" + rule + ", " + moduleIds + ")"
+  }
+  private[this] def copy(rule: com.eed3si9n.jarjarabrams.ShadeRule = rule, moduleIds: Vector[sbt.librarymanagement.ModuleID] = moduleIds): AssemblyShadeRule = {
+    new AssemblyShadeRule(rule, moduleIds)
+  }
+  def withRule(rule: com.eed3si9n.jarjarabrams.ShadeRule): AssemblyShadeRule = {
+    copy(rule = rule)
+  }
+  def withModuleIds(moduleIds: Vector[sbt.librarymanagement.ModuleID]): AssemblyShadeRule = {
+    copy(moduleIds = moduleIds)
+  }
+}
+object AssemblyShadeRule {
+  trait implicits {
+    implicit def assemblyShadeRuleFromShareRule(rule: com.eed3si9n.jarjarabrams.ShadeRule): AssemblyShadeRule = AssemblyShadeRule(rule)
+    implicit def assemblyShadeRuleFromShadePattern(pattern: com.eed3si9n.jarjarabrams.ShadePattern): AssemblyShadeRule = AssemblyShadeRule(pattern)
+  }
+  def apply(rule: com.eed3si9n.jarjarabrams.ShadeRule): AssemblyShadeRule = AssemblyShadeRule(rule, Vector.empty)
+  def apply(pattern: com.eed3si9n.jarjarabrams.ShadePattern): AssemblyShadeRule = AssemblyShadeRule(com.eed3si9n.jarjarabrams.ShadeRule(pattern, Vector.empty))
+  def apply(rule: com.eed3si9n.jarjarabrams.ShadeRule, moduleIds: Vector[sbt.librarymanagement.ModuleID]): AssemblyShadeRule = new AssemblyShadeRule(rule, moduleIds)
+}

--- a/src/sbt-test/shading/shading/build.sbt
+++ b/src/sbt-test/shading/shading/build.sbt
@@ -3,12 +3,16 @@ lazy val testshade = (project in file(".")).
     version := "0.1",
     assembly / assemblyJarName := "foo.jar",
     scalaVersion := "2.12.18",
-    libraryDependencies += "commons-io" % "commons-io" % "2.4",
+    libraryDependencies ++= Seq(
+      "commons-io" % "commons-io" % "2.4",
+      "org.json4s" %% "json4s-ast" % "4.0.6"
+    ),
     assembly / assemblyShadeRules := Seq(
       ShadeRule.zap("remove.**").inProject,
       ShadeRule.rename("toshade.classes.ShadeClass" -> "toshade.classez.ShadedClass").inProject,
       ShadeRule.rename("toshade.ShadePackage" -> "shaded_package.ShadePackage").inProject,
-      ShadeRule.rename("org.apache.commons.io.**" -> "shadeio.@1").inLibrary("commons-io" % "commons-io" % "2.4").inProject
+      ShadeRule.rename("org.apache.commons.io.**" -> "shadeio.@1").inLibrary("commons-io" % "commons-io" % "2.4").inProject,
+      ShadeRule.rename("org.json4s.**" -> "shadejson4s.@1").inLibrary("org.json4s" %% "json4s-ast" % "4.0.6").inProject
     ),
     // logLevel in assembly := Level.Debug,
     TaskKey[Unit]("check") := {
@@ -16,9 +20,11 @@ lazy val testshade = (project in file(".")).
         IO.unzip(crossTarget.value / "foo.jar", dir)
         mustNotExist(dir / "remove" / "Removed.class")
         mustNotExist(dir / "org" / "apache" / "commons" / "io" / "ByteOrderMark.class")
+        mustNotExist(dir / "org" / "json4s" / "BuildInfo.class")
         mustExist(dir / "shaded_package" / "ShadePackage.class")
         mustExist(dir / "toshade" / "classez" / "ShadedClass.class")
         mustExist(dir / "shadeio" / "ByteOrderMark.class")
+        mustExist(dir / "shadejson4s" / "BuildInfo.class")
       }
       val process = sys.process.Process("java", Seq("-jar", (crossTarget.value / "foo.jar").toString))
       val out = (process!!)


### PR DESCRIPTION
Resolve #403

Support to convert cross-versioned `ModuleID` to `ModuleCoordinate`.

#### Background

- [`ShadePattern.inLibrary`](https://github.com/sbt/sbt-assembly/blob/f2b4744ebecef67b9f1dcb5cecab3d78ea65ba79/src/main/scala/sbtassembly/AssemblyPlugin.scala#L19-L25) extension method provides an easy way to add sbt-librarymanagement's `ModuleID` as jarjar-abrams's `ModuleCoordinate` to `ShadeRule`.
- However, current conversion from `ModuleID` to `ModuleCoordinate` does not support for cross-versioned `ModuleID`.

#### Consideration
- Should be completed on sbt-assembly plugin layer.
  - This support should essentially be provided in sbt-assembly plugin, so it is not good to modify jarjar-abrams.
- Should not break current syntax.
  - Introduce wrapper class `AssemblyShadeRule` for `ShadeRule` without modifying jarjar-abrams.
  - Provide implicit conversion for compatibility.
