### PR TITLE
Update to Jar Jar Abrams 1.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,23 @@ jobs:
       shell: bash
       run: |
         sbt -v clean scripted
+
+  ea-test:
+    runs-on: ubuntu-latest
+    env:
+      # define Java options for both official sbt and sbt-extras
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: 22-ea
+        distribution: temurin
+        jdkFile: https://download.java.net/java/early_access/jdk22/20/GPL/openjdk-22-ea+20_linux-x64_bin.tar.gz
+        cache: sbt
+    - name: Build and test
+      shell: bash
+      run: |
+        sbt -v clean scripted

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val root = (project in file("."))
     name := "sbt-assembly"
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024", "-Xfuture")
     libraryDependencies ++= Seq(
-      "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "1.9.0",
+      "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "1.13.0",
     )
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -488,7 +488,11 @@ object Assembly {
     if (shadeRules.isEmpty)
       (name: String, inputStream: LazyInputStream) => Some(name -> inputStream)
     else {
-      val bytecodeShader = Shader.bytecodeShader(shadeRules, verbose = false)
+      val bytecodeShader = Shader.bytecodeShader(
+        shadeRules,
+        verbose = false,
+        skipManifest = false,
+      )
       (name: String, inputStream: LazyInputStream) => {
         val is = inputStream()
         val shadeResult = bytecodeShader(Streamable.bytes(is), name)


### PR DESCRIPTION
- https://github.com/eed3si9n/jarjar-abrams/releases/tag/v1.13.0 (JDK 22-ea support)
- https://github.com/eed3si9n/jarjar-abrams/releases/tag/v1.10.0 (set dates to 2010)