### PR TITLE
Bump jarjar-abrams to 1.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val root = (project in file("."))
     name := "sbt-assembly"
     scalacOptions := Seq("-deprecation", "-unchecked", "-Dscalac.patmat.analysisBudget=1024", "-Xfuture")
     libraryDependencies ++= Seq(
-      "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "1.13.0",
+      "com.eed3si9n.jarjarabrams" %% "jarjar-abrams-core" % "1.13.1",
     )
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {


### PR DESCRIPTION
# Description
Bump jarjar-abrams to 1.13.1 ([changelog](https://github.com/eed3si9n/jarjar-abrams/releases/tag/v1.13.1)).

# Testing
Built locally `sbt-assembly` with the new version and confirmed this solves issue #479 for us.
