### PR TITLE
Misconfigured 'assemblyOutputPath' can be dangerous

### DIFF
--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -347,8 +347,15 @@ object Assembly {
           .getOrElse(System.currentTimeMillis())
 
         timed(Level.Debug, "Create jar") {
-          IO.delete(output)
-          createJar(output, jarEntriesToWrite, jarManifest, localTime)
+          if (output.isDirectory) {
+            val invalidPath = output.toPath.toAbsolutePath.normalize
+            log.error(s"Attempted to overwrite existing directory: $invalidPath")
+            log.error("Update 'assemblyOutputPath' key or manually delete the corresponding path.")
+            throw new RuntimeException("Exiting task")
+          } else {
+            IO.delete(output)
+            createJar(output, jarEntriesToWrite, jarManifest, localTime)
+          }
         }
         val fullSha1 = timed(Level.Debug, "Hash newly-built Jar") {
           hash(output)

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -349,8 +349,7 @@ object Assembly {
         timed(Level.Debug, "Create jar") {
           if (output.isDirectory) {
             val invalidPath = output.toPath.toAbsolutePath.normalize
-            log.error(s"Attempted to overwrite existing directory: $invalidPath")
-            log.error("Update 'assemblyOutputPath' key or manually delete the corresponding path.")
+            log.error(s"expected a file name for assemblyOutputPath, but found a directory: ${invalidPath}; fix the setting or delete the directory")
             throw new RuntimeException("Exiting task")
           } else {
             IO.delete(output)


### PR DESCRIPTION
Hello,

In a complete PEBKAC moment I essentially did
```
assembly / assemblyOutputPath := file(".")
```
which resulted in sawing off the proverbial and also literal branch I was sitting on.

I don't believe this is the behavior anyone would ever intend.

Shootout to IntellIJ IDEA's local history feature.