### PR TITLE
fix compile error with JDK 23

### DIFF
--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -17,7 +17,7 @@ import CacheImplicits._
 import sbtassembly.AssemblyPlugin.autoImport.{ Assembly => _, _ }
 import sbtassembly.PluginCompat.ClasspathUtilities
 
-import java.io._
+import java.io.{ BufferedInputStream, ByteArrayInputStream, FileInputStream, InputStream }
 import java.net.URI
 import java.nio.file.attribute.{ BasicFileAttributeView, FileTime, PosixFilePermission }
 import java.nio.file.{ Path, _ }


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8305457

```
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:355:13: reference to IO is ambiguous;
[error] it is imported twice in the same scope by
[error] import java.io._
[error] and import sbt.{File, Logger, _}
[error]             IO.delete(output)
[error]             ^
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:371:13: reference to IO is ambiguous;
[error] it is imported twice in the same scope by
[error] import java.io._
[error] and import sbt.{File, Logger, _}
[error]             IO.delete(outputWithHash)
[error]             ^
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:379:31: reference to IO is ambiguous;
[error] it is imported twice in the same scope by
[error] import java.io._
[error] and import sbt.{File, Logger, _}
[error]               if (tmp.exists) IO.delete(tmp)
[error]                               ^
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:381:15: reference to IO is ambiguous;
[error] it is imported twice in the same scope by
[error] import java.io._
[error] and import sbt.{File, Logger, _}
[error]               IO.write(builtAssemblyJar, shellScript.map(_ + "\n").mkString, append = false)
[error]               ^
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:381:78: not found: value append
[error]               IO.write(builtAssemblyJar, shellScript.map(_ + "\n").mkString, append = false)
[error]                                                                              ^
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:382:69: reference to IO is ambiguous;
[error] it is imported twice in the same scope by
[error] import java.io._
[error] and import sbt.{File, Logger, _}
[error]               Using.fileOutputStream(true)(builtAssemblyJar)(out => IO.transfer(tmp, out))
[error]                                                                     ^
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:383:15: reference to IO is ambiguous;
[error] it is imported twice in the same scope by
[error] import java.io._
[error] and import sbt.{File, Logger, _}
[error]               IO.delete(tmp)
[error]               ^
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:533:13: reference to IO is ambiguous;
[error] it is imported twice in the same scope by
[error] import java.io._
[error] and import sbt.{File, Logger, _}
[error]             IO.delete(previousOutput.get)
[error]             ^
[error] sbt-assempby-project-dir/src/main/scala/sbtassembly/Assembly.scala:566:15: reference to IO is ambiguous;
[error] it is imported twice in the same scope by
[error] import java.io._
[error] and import sbt.{File, Logger, _}
[error]               IO.transfer(inputStream, outputStream)
[error]               ^
```