### PR TITLE
update scalacOptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,12 +17,21 @@ lazy val root = (project in file("."))
   .enablePlugins(SbtPlugin, ContrabandPlugin)
   .settings(nocomma {
     name := "sbt-assembly"
-    scalacOptions := Seq(
-      "-Xsource:3",
+    scalacOptions ++= {
+      scalaBinaryVersion.value match {
+        case "3" =>
+          Nil
+        case _ =>
+          Seq(
+            "-Xsource:3",
+            "-Xfuture",
+          )
+      }
+    }
+    scalacOptions ++= Seq(
       "-deprecation",
       "-unchecked",
       "-Dscalac.patmat.analysisBudget=1024",
-      "-Xfuture",
     )
     libraryDependencies += jarjar.cross(CrossVersion.for3Use2_13)
     (pluginCrossBuild / sbtVersion) := {


### PR DESCRIPTION
fix scala 3 warnings

```
[info] compiling 7 Scala sources to /home/runner/work/sbt-assembly/sbt-assembly/target/scala-3.3.4/sbt-2.0.0-M2/classes ...
[warn] bad option '-Xsource:3' was ignored
[warn] bad option '-Xfuture' was ignored
```