### PR TITLE
Partially replace compat layer with sbt2-compat plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ project/plugins/target
 project/plugins/project/build.properties
 .idea
 metals.sbt
-
 .vscode
 .cursor
 .metals

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ project/plugins/target
 project/plugins/project/build.properties
 .idea
 metals.sbt
+
+.vscode
+.cursor
+.metals

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val root = (project in file("."))
       "-Dscalac.patmat.analysisBudget=1024",
     )
     libraryDependencies += jarjar.cross(CrossVersion.for3Use2_13)
+    addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0-SNAPSHOT")
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.5.8"

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val root = (project in file("."))
       "-Dscalac.patmat.analysisBudget=1024",
     )
     libraryDependencies += jarjar.cross(CrossVersion.for3Use2_13)
-    addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0-SNAPSHOT")
+    addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {
         case "2.12" => "1.5.8"

--- a/src/main/scala-2.12/PluginCompat.scala
+++ b/src/main/scala-2.12/PluginCompat.scala
@@ -11,30 +11,9 @@ import sbt.util.Tracked.{ inputChanged, lastOutput }
 import xsbti.FileConverter
 
 private[sbtassembly] object PluginCompat {
-  type FileRef = java.io.File
-  type Out = java.io.File
   type MainClass = sbt.Package.MainClass
 
   object CollectionConverters
-
-  val moduleIDStr = Keys.moduleID.key
-  def parseModuleIDStrAttribute(m: ModuleID): ModuleID = m
-
-  def toNioPath(a: Attributed[File])(implicit conv: FileConverter): NioPath =
-    a.data.toPath()
-  def toFile(a: Attributed[File])(implicit conv: FileConverter): File =
-    a.data
-  def toOutput(x: File)(implicit conv: FileConverter): File =
-    x
-  def toNioPaths(cp: Seq[Attributed[File]])(implicit conv: FileConverter): Vector[NioPath] =
-    cp.map(_.data.toPath()).toVector
-  def toFiles(cp: Seq[Attributed[File]])(implicit conv: FileConverter): Vector[File] =
-    cp.map(_.data).toVector
-
-  // This adds `Def.uncached(...)`
-  implicit class DefOp(singleton: Def.type) {
-    def uncached[A1](a: A1): A1 = a
-  }
 
   def baseTestSettings: Seq[sbt.Def.Setting[?]] = Seq(
     AssemblyKeys.assembly / test := (()),

--- a/src/main/scala-3/PluginCompat.scala
+++ b/src/main/scala-3/PluginCompat.scala
@@ -5,33 +5,16 @@ import java.nio.file.{ Path => NioPath }
 import java.util.jar.{ Manifest => JManifest }
 import sbt.*
 import Keys.test
-import sbt.librarymanagement.ModuleID
 import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFile }
+import sbtcompat.PluginCompat.Out
 
 object PluginCompat:
-  type FileRef = HashedVirtualFileRef
-  type Out = VirtualFile
   type JarManifest = PackageOption.JarManifest
   type MainClass = PackageOption.MainClass
   type ManifestAttributes = PackageOption.ManifestAttributes
   type FixedTimestamp = PackageOption.FixedTimestamp
 
   val CollectionConverters = scala.collection.parallel.CollectionConverters
-
-  val moduleIDStr = Keys.moduleIDStr
-  def parseModuleIDStrAttribute(str: String): ModuleID =
-    Classpaths.moduleIdJsonKeyFormat.read(str)
-
-  def toNioPath(a: Attributed[HashedVirtualFileRef])(using conv: FileConverter): NioPath =
-    conv.toPath(a.data)
-  inline def toFile(a: Attributed[HashedVirtualFileRef])(using conv: FileConverter): File =
-    toNioPath(a).toFile()
-  def toOutput(x: File)(using conv: FileConverter): VirtualFile =
-    conv.toVirtualFile(x.toPath())
-  def toNioPaths(cp: Seq[Attributed[HashedVirtualFileRef]])(using conv: FileConverter): Vector[NioPath] =
-    cp.map(toNioPath).toVector
-  inline def toFiles(cp: Seq[Attributed[HashedVirtualFileRef]])(using conv: FileConverter): Vector[File] =
-    toNioPaths(cp).map(_.toFile())
 
   def baseTestSettings: Seq[sbt.Def.Setting[?]] = Seq(
     AssemblyKeys.assembly / test := TestResult.Empty,
@@ -67,7 +50,7 @@ object PluginCompat:
   ): CacheKey = 0
 
   private[sbtassembly] def cachedAssembly(inputs: CacheKey, cacheDir: File, scalaVersion: String, log: Logger)(
-      buildAssembly: () => PluginCompat.Out
-  ): PluginCompat.Out =
+      buildAssembly: () => Out
+  ): Out =
     buildAssembly()
 end PluginCompat

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -25,6 +25,7 @@ import scala.collection.JavaConverters._
 import scala.language.postfixOps
 import xsbti.FileConverter
 import PluginCompat.*
+import sbtcompat.PluginCompat.{FileRef, Out, toNioPath, toFile, toOutput, toNioPaths, toFiles, moduleIDStr, parseModuleIDStrAttribute}
 import CollectionConverters.{ given, * }
 
 object Assembly {
@@ -170,7 +171,7 @@ object Assembly {
     val jarName: String = s"$name${if (version.nonEmpty) "-" else ""}$version.jar"
   }
 
-  def assemblyTask(key: TaskKey[PluginCompat.FileRef]): Initialize[Task[PluginCompat.Out]] = Def.task {
+  def assemblyTask(key: TaskKey[FileRef]): Initialize[Task[Out]] = Def.task {
     val t = (key / test).value
     val s = (key / streams).value
     val conv = fileConverter.value
@@ -212,7 +213,7 @@ object Assembly {
       conv: FileConverter,
       cacheDir: File,
       log: Logger
-  ): PluginCompat.Out = {
+  ): Out = {
     def timed[A](level: Level.Value, desc: String)(f: => A): A = {
       log.log(level, desc + " start:")
       val start = Instant.now().toEpochMilli
@@ -286,8 +287,8 @@ object Assembly {
     val (jarFiles, jarFileEntries) = timed(Level.Debug, "Collect and shade dependency entries") {
       filteredJars.par.map { jar =>
         val module = jar.metadata
-          .get(PluginCompat.moduleIDStr)
-          .map(PluginCompat.parseModuleIDStrAttribute)
+          .get(moduleIDStr)
+          .map(parseModuleIDStrAttribute)
           .map(m => ModuleCoordinate(m.organization, m.name, m.revision))
           .getOrElse(ModuleCoordinate("", jar.data.name.replaceAll(".jar", ""), ""))
         val jarFile = new JarFile(toFile(jar))
@@ -322,7 +323,7 @@ object Assembly {
         if (mergeStrategy.name == MergeStrategy.rename.name) Option.empty
         else Option(mergeStrategy)
       }
-      val buildAssembly: () => PluginCompat.Out  = () => {
+      val buildAssembly: () => Out  = () => {
         val mergedEntries = timed(Level.Debug, "Merge all conflicting jar entries (including those renamed)") {
           merge(renamedDependencies ++ others, secondPassMergeStrategy, log)
         }

--- a/src/main/scala/sbtassembly/AssemblyKeys.scala
+++ b/src/main/scala/sbtassembly/AssemblyKeys.scala
@@ -3,20 +3,21 @@ package sbtassembly
 import com.eed3si9n.jarjarabrams
 import sbt.Keys.*
 import sbt.*
+import sbtcompat.PluginCompat.FileRef
 
 trait AssemblyKeys {
   @transient
-  lazy val assembly                  = taskKey[PluginCompat.FileRef]("Builds a deployable über JAR")
+  lazy val assembly                  = taskKey[FileRef]("Builds a deployable über JAR")
   lazy val assembleArtifact          = settingKey[Boolean]("Enables (true) or disables (false) assembling an artifact")
 
   @transient
   lazy val assemblyOption            = taskKey[AssemblyOption]("Configuration for making a deployable über JAR")
 
   @transient
-  lazy val assemblyPackageScala      = taskKey[PluginCompat.FileRef]("Produces the Scala artifact")
+  lazy val assemblyPackageScala      = taskKey[FileRef]("Produces the Scala artifact")
 
   @transient
-  lazy val assemblyPackageDependency = taskKey[PluginCompat.FileRef]("Produces the dependency artifact")
+  lazy val assemblyPackageDependency = taskKey[FileRef]("Produces the dependency artifact")
   lazy val assemblyJarName           = taskKey[String]("name of the über jar")
   lazy val assemblyDefaultJarName    = taskKey[String]("default name of the über jar")
   lazy val assemblyOutputPath        = taskKey[File]("output path of the über jar")

--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -4,6 +4,7 @@ import com.eed3si9n.jarjarabrams
 import sbt.Keys._
 import sbt.{ given, * }
 import PluginCompat.*
+import sbtcompat.PluginCompat.*
 
 object AssemblyPlugin extends sbt.AutoPlugin {
   override def requires = plugins.JvmPlugin


### PR DESCRIPTION
This PR attempts to shrink the existing compat layer between sbt 1 and 2 by using [sbt2-compat plugin](https://github.com/anatoliykmetyuk/sbt2-compat).

Status: CI is failing due to the sbt2-compat plugin not being published yet.

TODO:

- [x] Publish the compat plugin to Maven
- [x] Update this PR to use the published version (currently uses a local SNAPSHOT)