### PR TITLE
Fix warning in test

### DIFF
--- a/src/sbt-test/shading/scalasigannot/build.sbt
+++ b/src/sbt-test/shading/scalasigannot/build.sbt
@@ -8,7 +8,7 @@ lazy val scala213 = "2.13.11"
 ThisBuild / crossScalaVersions := List(scala212, scala213)
 
 
-val shadingSettings: Seq[Def.Setting[_]] = Seq(
+val shadingSettings: Seq[Def.Setting[?]] = Seq(
   exportJars := false,
   assembly / assemblyShadeRules := Seq(
     ShadeRule.rename(


### PR DESCRIPTION
```
Error:  -- Warning: /tmp/sbt_45a394cf/build.sbt:3:37 -----------------------------------
Error:  3 |val shadingSettings: Seq[Def.Setting[_]] = Seq(
Error:    |                                     ^
Error:    |`_` is deprecated for wildcard arguments of types: use `?` instead
Error:    |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```