### PR TITLE
Fix and unify assembly output caching across sbt 1 and sbt 2

### DIFF
--- a/src/main/scala-2.12/PluginCompat.scala
+++ b/src/main/scala-2.12/PluginCompat.scala
@@ -1,14 +1,7 @@
 package sbtassembly
 
-import java.nio.file.{ Path => NioPath }
-import java.util.jar.{ Manifest => JManifest }
 import sbt.*
-import Keys.test
-import sbt.internal.util.HNil
-import sbt.internal.util.Types.:+:
-import sbt.util.FileInfo.lastModified
-import sbt.util.Tracked.{ inputChanged, lastOutput }
-import xsbti.FileConverter
+import sbt.Keys.test
 
 private[sbtassembly] object PluginCompat {
   type MainClass = sbt.Package.MainClass
@@ -21,59 +14,15 @@ private[sbtassembly] object PluginCompat {
     AssemblyKeys.assemblyPackageDependency / test := (AssemblyKeys.assembly / test).value,
   )
 
-  type CacheKey = FilesInfo[ModifiedFileInfo] :+:
-    Map[String, (Boolean, String)] :+: // map of target paths that matched a merge strategy
-    JManifest :+:
-    // Assembly options...
-    Boolean :+:
-    Option[Seq[String]] :+:
-    Option[Int] :+:
-    Boolean :+:
-    HNil
-
-  val HListFormats = sbt.internal.util.HListFormats
   val Streamable = scala.tools.nsc.io.Streamable
 
-  private[sbtassembly] def makeCacheKey(
-    classes: Vector[NioPath],
-    filteredJars: Vector[Attributed[File]],
-    mergeStrategiesByPathList: Map[String, (Boolean, String)],
-    jarManifest: JManifest,
-    ao: AssemblyOption,
-  ): CacheKey =
-    lastModified(classes.map(_.toFile()).toSet ++ filteredJars.map(_.data).toSet) :+:
-      mergeStrategiesByPathList :+:
-      jarManifest :+:
-      ao.repeatableBuild :+:
-      ao.prependShellScript :+:
-      ao.maxHashLength :+:
-      ao.appendContentHash :+:
-      HNil
-
-  // sbt 1.x style disk cache
   private[sbtassembly] def cachedAssembly(inputs: CacheKey, cacheDir: File, scalaVersion: String, log: Logger)(
       buildAssembly: () => File
   ): File = {
-    import CacheImplicits._
-    import sbt.internal.util.HListFormats._
-    import sbt.Package.manifestFormat
-    val cacheBlock = inputChanged(cacheDir / s"assembly-cacheKey-$scalaVersion") { (inputChanged, _: CacheKey) =>
-      lastOutput(cacheDir / s"assembly-outputs-$scalaVersion") { (_: Unit, previousOutput: Option[File]) =>
-        val outputExists = previousOutput.exists(_.exists())
-        (inputChanged, outputExists) match {
-          case (false, true) =>
-            log.info("Assembly jar up to date: " + previousOutput.get.toPath)
-            previousOutput.get
-          case (true, true) =>
-            log.debug("Building assembly jar due to changed inputs...")
-            IO.delete(previousOutput.get)
-            buildAssembly()
-          case (_, _) =>
-            log.debug("Building assembly jar due to missing output...")
-            buildAssembly()
-        }
-      }
-    }
-    cacheBlock(inputs)(Unit)
+    AssemblyCache.cachedAssembly[File, File](inputs, cacheDir, scalaVersion, log)(
+      toCachedOutput = identity,
+      fromCachedOutput = identity,
+      cachedOutputFile = identity
+    )(buildAssembly)
   }
 }

--- a/src/main/scala-3/PluginCompat.scala
+++ b/src/main/scala-3/PluginCompat.scala
@@ -4,9 +4,13 @@ import java.io.File
 import java.nio.file.{ Path => NioPath }
 import java.util.jar.{ Manifest => JManifest }
 import sbt.*
-import Keys.test
+import sbt.Keys.test
 import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFile }
-import sbtcompat.PluginCompat.Out
+import sbtcompat.PluginCompat.{ Out, toFile, toOutput }
+import sbt.util.{ FilesInfo, ModifiedFileInfo }
+import sbt.util.FileInfo.lastModified
+import sbt.util.Tracked.{ inputChanged, lastOutput }
+import sjsonnew.{ BasicJsonProtocol, JsonFormat }
 
 object PluginCompat:
   type JarManifest = PackageOption.JarManifest
@@ -40,17 +44,100 @@ object PluginCompat:
 
   val inTask = Project.inTask
 
-  type CacheKey = Int
+  /**
+   * Input state used to determine whether an SBT 2 assembly output can be reused.
+   *
+   * This is a direct port of the SBT 1 cache key in `src/main/scala-2.12/PluginCompat.scala`
+   *
+   * @param assemblyInputFileStamps modification-time information for compiled class/resource
+   *   outputs and selected JARs on the resolved assembly classpath; source files are not watched directly
+   * @param resolvedMergeStrategyInfoByTargetPath resolved merge-strategy information, indexed by target path
+   * @param jarManifest manifest written to the output JAR
+   * @param repeatableBuild whether output JAR entries are sorted by target path before writing to
+   *   make the output bytes deterministic for reproducible builds
+   * @param prependShellScript optional script prepended to the output JAR
+   * @param maxHashLength optional maximum length of the SHA-1 appended to the output file name
+   * @param appendContentHash whether the content hash is appended to the output file name.
+   *   When `appendContentHash` is enabled, the output name changes from, for example,
+   *   `app-assembly.jar` to `app-assembly-a1b2c3.jar`; `maxHashLength` selects how much of the
+   *   SHA-1 is appended. Changing it therefore requires a rebuild for the requested output path.
+   *   When content-hash appending is disabled, `maxHashLength` has no output effect, but retaining
+   *   it in the key is a safe, redundant invalidation.
+   */
+  private[sbtassembly] final case class CacheKey(
+    assemblyInputFileStamps: FilesInfo[ModifiedFileInfo],
+    resolvedMergeStrategyInfoByTargetPath: Map[String, (Boolean, String)],
+    jarManifest: JManifest,
+    repeatableBuild: Boolean,
+    prependShellScript: Option[Seq[String]],
+    maxHashLength: Option[Int],
+    appendContentHash: Boolean,
+  )
+
+  private[sbtassembly] object CacheKey:
+    import BasicJsonProtocol.given
+    import sbt.Package.manifestFormat
+
+    given JsonFormat[CacheKey] = BasicJsonProtocol.caseClass7(
+      CacheKey.apply,
+      key => Some((
+        key.assemblyInputFileStamps,
+        key.resolvedMergeStrategyInfoByTargetPath,
+        key.jarManifest,
+        key.repeatableBuild,
+        key.prependShellScript,
+        key.maxHashLength,
+        key.appendContentHash,
+      )),
+    )(
+      "assemblyInputFileStamps",
+      "resolvedMergeStrategyInfoByTargetPath",
+      "jarManifest",
+      "repeatableBuild",
+      "prependShellScript",
+      "maxHashLength",
+      "appendContentHash",
+    )
+
   private[sbtassembly] def makeCacheKey(
     classes: Vector[NioPath],
     filteredJars: Vector[Attributed[HashedVirtualFileRef]],
     mergeStrategiesByPathList: Map[String, (Boolean, String)],
     jarManifest: JManifest,
     ao: AssemblyOption,
-  ): CacheKey = 0
+  )(using conv: FileConverter): CacheKey =
+    CacheKey(
+      assemblyInputFileStamps = lastModified(classes.map(_.toFile).toSet ++ filteredJars.map(toFile(_)).toSet),
+      resolvedMergeStrategyInfoByTargetPath = mergeStrategiesByPathList,
+      jarManifest = jarManifest,
+      repeatableBuild = ao.repeatableBuild,
+      prependShellScript = ao.prependShellScript,
+      maxHashLength = ao.maxHashLength,
+      appendContentHash = ao.appendContentHash,
+    )
 
   private[sbtassembly] def cachedAssembly(inputs: CacheKey, cacheDir: File, scalaVersion: String, log: Logger)(
       buildAssembly: () => Out
-  ): Out =
-    buildAssembly()
+  )(using conv: FileConverter): Out = {
+    import CacheKey.given
+
+    val cacheBlock = inputChanged(cacheDir / s"assembly-cacheKey-$scalaVersion") { (inputChanged, _: CacheKey) =>
+      lastOutput(cacheDir / s"assembly-outputs-$scalaVersion") { (_: Unit, previousOutput: Option[String]) =>
+        val outputExists = previousOutput.exists(path => new File(path).exists)
+        (inputChanged, outputExists) match {
+          case (false, true) =>
+            log.info(s"Assembly jar up to date: ${previousOutput.get}")
+            previousOutput.get
+          case (true, true) =>
+            log.debug("Building assembly jar due to changed inputs...")
+            sbt.io.IO.delete(new File(previousOutput.get))
+            toFile(buildAssembly()).getAbsolutePath
+          case (_, _) =>
+            log.debug("Building assembly jar due to missing output...")
+            toFile(buildAssembly()).getAbsolutePath
+        }
+      }
+    }
+    toOutput(new File(cacheBlock(inputs)(())))
+  }
 end PluginCompat

--- a/src/main/scala-3/PluginCompat.scala
+++ b/src/main/scala-3/PluginCompat.scala
@@ -1,16 +1,11 @@
 package sbtassembly
 
 import java.io.File
-import java.nio.file.{ Path => NioPath }
-import java.util.jar.{ Manifest => JManifest }
 import sbt.*
 import sbt.Keys.test
-import xsbti.{ FileConverter, HashedVirtualFileRef, VirtualFile }
+import xsbti.FileConverter
 import sbtcompat.PluginCompat.{ Out, toFile, toOutput }
-import sbt.util.{ FilesInfo, ModifiedFileInfo }
-import sbt.util.FileInfo.lastModified
-import sbt.util.Tracked.{ inputChanged, lastOutput }
-import sjsonnew.{ BasicJsonProtocol, JsonFormat }
+import sjsonnew.BasicJsonProtocol
 
 object PluginCompat:
   type JarManifest = PackageOption.JarManifest
@@ -44,100 +39,21 @@ object PluginCompat:
 
   val inTask = Project.inTask
 
-  /**
-   * Input state used to determine whether an SBT 2 assembly output can be reused.
-   *
-   * This is a direct port of the SBT 1 cache key in `src/main/scala-2.12/PluginCompat.scala`
-   *
-   * @param assemblyInputFileStamps modification-time information for compiled class/resource
-   *   outputs and selected JARs on the resolved assembly classpath; source files are not watched directly
-   * @param resolvedMergeStrategyInfoByTargetPath resolved merge-strategy information, indexed by target path
-   * @param jarManifest manifest written to the output JAR
-   * @param repeatableBuild whether output JAR entries are sorted by target path before writing to
-   *   make the output bytes deterministic for reproducible builds
-   * @param prependShellScript optional script prepended to the output JAR
-   * @param maxHashLength optional maximum length of the SHA-1 appended to the output file name
-   * @param appendContentHash whether the content hash is appended to the output file name.
-   *   When `appendContentHash` is enabled, the output name changes from, for example,
-   *   `app-assembly.jar` to `app-assembly-a1b2c3.jar`; `maxHashLength` selects how much of the
-   *   SHA-1 is appended. Changing it therefore requires a rebuild for the requested output path.
-   *   When content-hash appending is disabled, `maxHashLength` has no output effect, but retaining
-   *   it in the key is a safe, redundant invalidation.
-   */
-  private[sbtassembly] final case class CacheKey(
-    assemblyInputFileStamps: FilesInfo[ModifiedFileInfo],
-    resolvedMergeStrategyInfoByTargetPath: Map[String, (Boolean, String)],
-    jarManifest: JManifest,
-    repeatableBuild: Boolean,
-    prependShellScript: Option[Seq[String]],
-    maxHashLength: Option[Int],
-    appendContentHash: Boolean,
-  )
-
-  private[sbtassembly] object CacheKey:
-    import BasicJsonProtocol.given
-    import sbt.Package.manifestFormat
-
-    given JsonFormat[CacheKey] = BasicJsonProtocol.caseClass7(
-      CacheKey.apply,
-      key => Some((
-        key.assemblyInputFileStamps,
-        key.resolvedMergeStrategyInfoByTargetPath,
-        key.jarManifest,
-        key.repeatableBuild,
-        key.prependShellScript,
-        key.maxHashLength,
-        key.appendContentHash,
-      )),
-    )(
-      "assemblyInputFileStamps",
-      "resolvedMergeStrategyInfoByTargetPath",
-      "jarManifest",
-      "repeatableBuild",
-      "prependShellScript",
-      "maxHashLength",
-      "appendContentHash",
-    )
-
-  private[sbtassembly] def makeCacheKey(
-    classes: Vector[NioPath],
-    filteredJars: Vector[Attributed[HashedVirtualFileRef]],
-    mergeStrategiesByPathList: Map[String, (Boolean, String)],
-    jarManifest: JManifest,
-    ao: AssemblyOption,
-  )(using conv: FileConverter): CacheKey =
-    CacheKey(
-      assemblyInputFileStamps = lastModified(classes.map(_.toFile).toSet ++ filteredJars.map(toFile(_)).toSet),
-      resolvedMergeStrategyInfoByTargetPath = mergeStrategiesByPathList,
-      jarManifest = jarManifest,
-      repeatableBuild = ao.repeatableBuild,
-      prependShellScript = ao.prependShellScript,
-      maxHashLength = ao.maxHashLength,
-      appendContentHash = ao.appendContentHash,
-    )
-
   private[sbtassembly] def cachedAssembly(inputs: CacheKey, cacheDir: File, scalaVersion: String, log: Logger)(
       buildAssembly: () => Out
   )(using conv: FileConverter): Out = {
-    import CacheKey.given
+    import BasicJsonProtocol.given
 
-    val cacheBlock = inputChanged(cacheDir / s"assembly-cacheKey-$scalaVersion") { (inputChanged, _: CacheKey) =>
-      lastOutput(cacheDir / s"assembly-outputs-$scalaVersion") { (_: Unit, previousOutput: Option[String]) =>
-        val outputExists = previousOutput.exists(path => new File(path).exists)
-        (inputChanged, outputExists) match {
-          case (false, true) =>
-            log.info(s"Assembly jar up to date: ${previousOutput.get}")
-            previousOutput.get
-          case (true, true) =>
-            log.debug("Building assembly jar due to changed inputs...")
-            sbt.io.IO.delete(new File(previousOutput.get))
-            toFile(buildAssembly()).getAbsolutePath
-          case (_, _) =>
-            log.debug("Building assembly jar due to missing output...")
-            toFile(buildAssembly()).getAbsolutePath
-        }
-      }
-    }
-    toOutput(new File(cacheBlock(inputs)(())))
+    AssemblyCache.cachedAssembly[Out, String](inputs, cacheDir, scalaVersion, log)(
+      toCachedOutput = {  output =>
+        toFile(output).getAbsolutePath
+      },
+      fromCachedOutput = { path =>
+        toOutput(new File(path))
+      },
+      cachedOutputFile = { path =>
+        new File(path)
+      },
+    )(buildAssembly)
   }
 end PluginCompat

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -431,6 +431,8 @@ object Assembly {
           classes.map(_.toFile()).toSet ++ filteredJars.map(toFile(_)).toSet,
           mergeStrategiesByPathList,
           jarManifest,
+          timestamp,
+          output,
           ao,
         )
         cachedAssembly(cacheKey, cacheDir, ao.scalaVersion, log)(buildAssembly)

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -427,9 +427,8 @@ object Assembly {
           }
       ) {
         val (_, classes) = classByParentDir.unzip
-        val cacheKey = makeCacheKey(
-          classes,
-          filteredJars,
+        val cacheKey = AssemblyCache.makeCacheKey(
+          classes.map(_.toFile()).toSet ++ filteredJars.map(toFile(_)).toSet,
           mergeStrategiesByPathList,
           jarManifest,
           ao,

--- a/src/main/scala/sbtassembly/AssemblyCache.scala
+++ b/src/main/scala/sbtassembly/AssemblyCache.scala
@@ -1,0 +1,108 @@
+package sbtassembly
+
+import java.util.jar.Manifest as JManifest
+import sbt.*
+import sbt.util.{ FilesInfo, ModifiedFileInfo }
+import sbt.util.FileInfo.lastModified
+import sbt.util.Tracked
+import sjsonnew.{ BasicJsonProtocol, JsonFormat }
+
+/**
+ * Input state used to determine whether an assembly output can be reused.
+ *
+ * @param assemblyInputFileStamps               modification-time information for compiled class/resource outputs
+ *                                              and selected JARs on the resolved assembly classpath; source files are not watched directly
+ * @param resolvedMergeStrategyInfoByTargetPath resolved merge-strategy information, indexed by target path
+ * @param jarManifest                           manifest written to the output JAR
+ * @param repeatableBuild                       whether output JAR entries are sorted by target path before writing to
+ *                                              make the output bytes deterministic for reproducible builds
+ * @param prependShellScript                    optional script prepended to the output JAR
+ * @param maxHashLength                         optional maximum length of the SHA-1 appended to the output file name
+ * @param appendContentHash                     whether the content hash is appended to the output file name.
+ *                                              When `appendContentHash` is enabled, the output name changes from, for example,
+ *                                              `app-assembly.jar` to `app-assembly-a1b2c3.jar`; `maxHashLength` selects how much of the
+ *                                              SHA-1 is appended. Changing it therefore requires a rebuild for the requested output path.
+ *                                              When content-hash appending is disabled, `maxHashLength` has no output effect, but retaining
+ *                                              it in the key is a safe, redundant invalidation.
+ */
+private[sbtassembly] final case class CacheKey(
+  assemblyInputFileStamps: FilesInfo[ModifiedFileInfo],
+  resolvedMergeStrategyInfoByTargetPath: Map[String, (Boolean, String)],
+  jarManifest: JManifest,
+  repeatableBuild: Boolean,
+  prependShellScript: Option[Seq[String]],
+  maxHashLength: Option[Int],
+  appendContentHash: Boolean,
+)
+
+private[sbtassembly] object CacheKey {
+  import CacheImplicits._
+  import sbt.Package.manifestFormat
+
+  implicit val format: JsonFormat[CacheKey] = BasicJsonProtocol.caseClassArray7(
+    CacheKey.apply,
+    key => Some((
+      key.assemblyInputFileStamps,
+      key.resolvedMergeStrategyInfoByTargetPath,
+      key.jarManifest,
+      key.repeatableBuild,
+      key.prependShellScript,
+      key.maxHashLength,
+      key.appendContentHash,
+    )),
+  )
+}
+
+private[sbtassembly] object AssemblyCache {
+  def makeCacheKey(
+    inputFiles: Set[File],
+    mergeStrategiesByPathList: Map[String, (Boolean, String)],
+    jarManifest: JManifest,
+    ao: AssemblyOption,
+  ): CacheKey =
+    CacheKey(
+      assemblyInputFileStamps = lastModified(inputFiles),
+      resolvedMergeStrategyInfoByTargetPath = mergeStrategiesByPathList,
+      jarManifest = jarManifest,
+      repeatableBuild = ao.repeatableBuild,
+      prependShellScript = ao.prependShellScript,
+      maxHashLength = ao.maxHashLength,
+      appendContentHash = ao.appendContentHash,
+    )
+
+  def cachedAssembly[Out, CachedOut](
+    inputs: CacheKey,
+    cacheDir: File,
+    scalaVersion: String,
+    log: Logger,
+  )(
+    toCachedOutput: Out => CachedOut,
+    fromCachedOutput: CachedOut => Out,
+    cachedOutputFile: CachedOut => File,
+  )(
+    buildAssembly: () => Out,
+  )(implicit cachedOutputFormat: JsonFormat[CachedOut]): Out = {
+    import CacheKey.format
+
+    val cacheBlock = Tracked.inputChanged[CacheKey, Unit => CachedOut](cacheDir / s"assembly-cacheKey-$scalaVersion") {
+      (inputChanged, _: CacheKey) =>
+        Tracked.lastOutput[Unit, CachedOut](cacheDir / s"assembly-outputs-$scalaVersion") { (_: Unit, previousOutput: Option[CachedOut]) =>
+          val previousOutputFile = previousOutput.map(cachedOutputFile)
+          val outputExists = previousOutputFile.exists(_.exists())
+          (inputChanged, outputExists) match {
+            case (false, true) =>
+              log.info("Assembly jar up to date: " + previousOutputFile.get.toPath)
+              previousOutput.get
+            case (true, true) =>
+              log.debug("Building assembly jar due to changed inputs...")
+              IO.delete(previousOutputFile.get)
+              toCachedOutput(buildAssembly())
+            case (_, _) =>
+              log.debug("Building assembly jar due to missing output...")
+              toCachedOutput(buildAssembly())
+          }
+        }
+    }
+    fromCachedOutput(cacheBlock(inputs)(()))
+  }
+}

--- a/src/main/scala/sbtassembly/AssemblyCache.scala
+++ b/src/main/scala/sbtassembly/AssemblyCache.scala
@@ -24,6 +24,8 @@ import sjsonnew.{ BasicJsonProtocol, JsonFormat }
  *                                              SHA-1 is appended. Changing it therefore requires a rebuild for the requested output path.
  *                                              When content-hash appending is disabled, `maxHashLength` has no output effect, but retaining
  *                                              it in the key is a safe, redundant invalidation.
+ * @param fixedTimestamp                        optional fixed timestamp applied to entries written to the output JAR
+ * @param assemblyOutputPath                    normalized absolute path requested for the output JAR
  */
 private[sbtassembly] final case class CacheKey(
   assemblyInputFileStamps: FilesInfo[ModifiedFileInfo],
@@ -33,13 +35,15 @@ private[sbtassembly] final case class CacheKey(
   prependShellScript: Option[Seq[String]],
   maxHashLength: Option[Int],
   appendContentHash: Boolean,
+  fixedTimestamp: Option[Long],
+  assemblyOutputPath: String,
 )
 
 private[sbtassembly] object CacheKey {
   import CacheImplicits._
   import sbt.Package.manifestFormat
 
-  implicit val format: JsonFormat[CacheKey] = BasicJsonProtocol.caseClassArray7(
+  implicit val format: JsonFormat[CacheKey] = BasicJsonProtocol.caseClassArray9(
     CacheKey.apply,
     key => Some((
       key.assemblyInputFileStamps,
@@ -49,6 +53,8 @@ private[sbtassembly] object CacheKey {
       key.prependShellScript,
       key.maxHashLength,
       key.appendContentHash,
+      key.fixedTimestamp,
+      key.assemblyOutputPath,
     )),
   )
 }
@@ -58,6 +64,8 @@ private[sbtassembly] object AssemblyCache {
     inputFiles: Set[File],
     mergeStrategiesByPathList: Map[String, (Boolean, String)],
     jarManifest: JManifest,
+    fixedTimestamp: Option[Long],
+    assemblyOutputPath: File,
     ao: AssemblyOption,
   ): CacheKey =
     CacheKey(
@@ -68,6 +76,8 @@ private[sbtassembly] object AssemblyCache {
       prependShellScript = ao.prependShellScript,
       maxHashLength = ao.maxHashLength,
       appendContentHash = ao.appendContentHash,
+      fixedTimestamp = fixedTimestamp,
+      assemblyOutputPath = assemblyOutputPath.getAbsoluteFile.toPath.normalize.toString,
     )
 
   def cachedAssembly[Out, CachedOut](

--- a/src/sbt-test/caching/cache-key-invalidation-per-parameter/build.sbt
+++ b/src/sbt-test/caching/cache-key-invalidation-per-parameter/build.sbt
@@ -13,8 +13,16 @@ lazy val checkAssemblyNotRebuilt = taskKey[Unit]("Checks that assembly did not r
 @transient
 lazy val checkAssemblyRebuilt = taskKey[Unit]("Checks that assembly rewrote its output")
 
+@transient
+lazy val checkAssemblyOutputExists = taskKey[Unit]("Checks that assembly produced its requested output")
+
+@transient
+lazy val checkAssemblyEntryTimestamps = taskKey[Unit]("Checks that assembly entries have the configured fixed timestamp")
+
 lazy val cacheKeyManifestValue = settingKey[String]("Value of a manifest attribute used by the cache-key test")
 lazy val cacheKeyMergeStrategy = settingKey[String]("Built-in conflict strategy used by the cache-key test")
+lazy val cacheKeyOutputName = settingKey[String]("Assembly output name used by the cache-key test")
+lazy val cacheKeyFixedTimestamp = settingKey[Long]("Fixed assembly entry timestamp used by the cache-key test")
 
 lazy val writeClass = inputKey[Unit]("Updates a compiled-class input")
 lazy val writeProcessedResource = inputKey[Unit]("Updates a processed-resource input")
@@ -89,15 +97,18 @@ def write(file: File, content: String): Unit = {
 lazy val root = (project in file(".")).settings(
   version := "0.1",
   scalaVersion := "2.12.18",
-  assembly / assemblyJarName := "cache-key.jar",
   cacheKeyManifestValue := "one",
   cacheKeyMergeStrategy := "first",
+  cacheKeyOutputName := "cache-key.jar",
+  cacheKeyFixedTimestamp := 1234567000L,
+  assembly / assemblyOutputPath := crossTarget.value / cacheKeyOutputName.value,
   Compile / unmanagedJars ++= {
     val conv = fileConverter.value
     implicit val c: xsbti.FileConverter = conv
     (baseDirectory.value / "lib" ** "cache-key-input.jar").classpath
   },
   assembly / packageOptions += Package.ManifestAttributes("Cache-Key-Test" -> cacheKeyManifestValue.value),
+  assembly / packageOptions += Package.FixedTimestamp(Some(cacheKeyFixedTimestamp.value)),
   assemblyMergeStrategy := {
     val conflictStrategy = cacheKeyMergeStrategy.value
     (path: String) =>
@@ -130,4 +141,20 @@ lazy val root = (project in file(".")).settings(
     Files.setLastModifiedTime(jar.toPath, FileTime.fromMillis(timestamp))
   },
   assemblyOutputAssertions,
+  checkAssemblyOutputExists := {
+    val output = (assembly / assemblyOutputPath).value
+    assert(output.isFile, s"assembly did not produce the requested output: $output")
+  },
+  checkAssemblyEntryTimestamps := {
+    val output = (assembly / assemblyOutputPath).value
+    val expected = cacheKeyFixedTimestamp.value - java.util.TimeZone.getDefault.getOffset(cacheKeyFixedTimestamp.value)
+    IO.withTemporaryDirectory { tmp =>
+      val files = IO.unzip(output, tmp)
+      assert(files.nonEmpty, s"assembly output has no entries: $output")
+      assert(
+        files.forall(_.lastModified == expected),
+        s"assembly entries do not have the configured fixed timestamp: $output",
+      )
+    }
+  },
 )

--- a/src/sbt-test/caching/cache-key-invalidation-per-parameter/build.sbt
+++ b/src/sbt-test/caching/cache-key-invalidation-per-parameter/build.sbt
@@ -1,0 +1,133 @@
+import java.io.{ File, FileOutputStream }
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+import java.util.jar.{ JarEntry, JarOutputStream }
+
+@transient
+lazy val recordAssemblyOutput = taskKey[Unit]("Records the current assembly output")
+
+@transient
+lazy val checkAssemblyNotRebuilt = taskKey[Unit]("Checks that assembly did not rewrite its output")
+
+@transient
+lazy val checkAssemblyRebuilt = taskKey[Unit]("Checks that assembly rewrote its output")
+
+lazy val cacheKeyManifestValue = settingKey[String]("Value of a manifest attribute used by the cache-key test")
+lazy val cacheKeyMergeStrategy = settingKey[String]("Built-in conflict strategy used by the cache-key test")
+
+lazy val writeClass = inputKey[Unit]("Updates a compiled-class input")
+lazy val writeProcessedResource = inputKey[Unit]("Updates a processed-resource input")
+lazy val writeDependencyJar = inputKey[Unit]("Updates a dependency-JAR input")
+
+lazy val assemblyOutputAssertions: Seq[Def.Setting[?]] = {
+  object AssemblyOutput {
+    private val recordFileName = "recorded-assembly-output.txt"
+
+    private def recordFile(crossTarget: File): File =
+      crossTarget / recordFileName
+
+    private def output(baseOutput: File): File =
+      if (baseOutput.exists) baseOutput
+      else {
+        val namePrefix = baseOutput.getName.stripSuffix(".jar") + "-"
+        val candidates = Option(baseOutput.getParentFile.listFiles).toSeq.flatten.filter { file =>
+          file.isFile && file.getName.startsWith(namePrefix) && file.getName.endsWith(".jar")
+        }
+        require(candidates.size == 1, s"Expected one hashed assembly output for $baseOutput, found $candidates")
+        candidates.head
+      }
+
+    private def snapshot(output: File): String =
+      s"${output.getAbsolutePath}\t${Files.getLastModifiedTime(output.toPath)}"
+
+    private def read(crossTarget: File): Array[String] =
+      IO.read(recordFile(crossTarget)).trim.split("\\t", 2)
+
+    def record(baseOutput: File, crossTarget: File): Unit =
+      IO.write(recordFile(crossTarget), snapshot(output(baseOutput)))
+
+    def assertChange(baseOutput: File, crossTarget: File, expectedChange: Boolean): Unit = {
+      val previous = read(crossTarget)
+      val current = snapshot(output(baseOutput)).split("\\t", 2)
+      val changed = previous(0) != current(0) || previous(1) != current(1)
+      assert(
+        changed == expectedChange,
+        if (expectedChange) s"assembly did not rewrite its output: ${current(0)}"
+        else s"unchanged assembly rewrote ${current(0)}: ${current(1)} (expected ${previous(1)})",
+      )
+    }
+  }
+
+  Seq(
+    recordAssemblyOutput := {
+      AssemblyOutput.record((assembly / assemblyOutputPath).value, crossTarget.value)
+    },
+    checkAssemblyNotRebuilt := {
+      AssemblyOutput.assertChange(
+        (assembly / assemblyOutputPath).value,
+        crossTarget.value,
+        expectedChange = false,
+      )
+    },
+    checkAssemblyRebuilt := {
+      AssemblyOutput.assertChange(
+        (assembly / assemblyOutputPath).value,
+        crossTarget.value,
+        expectedChange = true,
+      )
+    },
+  )
+}
+
+def write(file: File, content: String): Unit = {
+  IO.write(file, content)
+  val timestamp = math.max(System.currentTimeMillis(), file.lastModified + 1000L)
+  Files.setLastModifiedTime(file.toPath, FileTime.fromMillis(timestamp))
+}
+
+lazy val root = (project in file(".")).settings(
+  version := "0.1",
+  scalaVersion := "2.12.18",
+  assembly / assemblyJarName := "cache-key.jar",
+  cacheKeyManifestValue := "one",
+  cacheKeyMergeStrategy := "first",
+  Compile / unmanagedJars ++= {
+    val conv = fileConverter.value
+    implicit val c: xsbti.FileConverter = conv
+    (baseDirectory.value / "lib" ** "cache-key-input.jar").classpath
+  },
+  assembly / packageOptions += Package.ManifestAttributes("Cache-Key-Test" -> cacheKeyManifestValue.value),
+  assemblyMergeStrategy := {
+    val conflictStrategy = cacheKeyMergeStrategy.value
+    (path: String) =>
+      if (path == "conflict.txt" && conflictStrategy == "first") MergeStrategy.first
+      else if (path == "conflict.txt") MergeStrategy.last
+      else MergeStrategy.defaultMergeStrategy(path)
+  },
+  writeClass := {
+    val value = sbt.complete.Parsers.spaceDelimited("<value>").parsed.mkString(" ")
+    write((Compile / scalaSource).value / "Example.scala", s"""object Example { val value = "$value" }
+""")
+  },
+  writeProcessedResource := {
+    val value = sbt.complete.Parsers.spaceDelimited("<value>").parsed.mkString(" ")
+    write((Compile / classDirectory).value / "generated-resource.txt", value)
+  },
+  writeDependencyJar := {
+    val value = sbt.complete.Parsers.spaceDelimited("<value>").parsed.mkString(" ")
+    val jar = baseDirectory.value / "lib" / "cache-key-input.jar"
+    IO.createDirectory(jar.getParentFile)
+    val out = new JarOutputStream(new FileOutputStream(jar))
+    try {
+      Seq("conflict.txt" -> s"dependency-$value", "dependency.txt" -> value).foreach { case (name, content) =>
+        out.putNextEntry(new JarEntry(name))
+        out.write(content.getBytes(StandardCharsets.UTF_8))
+        out.closeEntry()
+      }
+    } finally out.close()
+    val timestamp = math.max(System.currentTimeMillis(), jar.lastModified + 1000L)
+    Files.setLastModifiedTime(jar.toPath, FileTime.fromMillis(timestamp))
+  },
+  assemblyOutputAssertions,
+)

--- a/src/sbt-test/caching/cache-key-invalidation-per-parameter/project/plugins.sbt
+++ b/src/sbt-test/caching/cache-key-invalidation-per-parameter/project/plugins.sbt
@@ -1,0 +1,6 @@
+val pluginVersion = System.getProperty("plugin.version")
+if (pluginVersion == null)
+  throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                              |Specify this property using the scriptedLaunchOpts -D.
+                              |""".stripMargin)
+else addSbtPlugin("com.eed3si9n" % "sbt-assembly" % pluginVersion)

--- a/src/sbt-test/caching/cache-key-invalidation-per-parameter/src/main/resources/conflict.txt
+++ b/src/sbt-test/caching/cache-key-invalidation-per-parameter/src/main/resources/conflict.txt
@@ -1,0 +1,1 @@
+project

--- a/src/sbt-test/caching/cache-key-invalidation-per-parameter/src/main/scala/Example.scala
+++ b/src/sbt-test/caching/cache-key-invalidation-per-parameter/src/main/scala/Example.scala
@@ -1,0 +1,3 @@
+object Example {
+  val value = "one"
+}

--- a/src/sbt-test/caching/cache-key-invalidation-per-parameter/test
+++ b/src/sbt-test/caching/cache-key-invalidation-per-parameter/test
@@ -50,6 +50,24 @@
 > assembly
 > checkAssemblyNotRebuilt
 
+# Package.FixedTimestamp (CacheKey.fixedTimestamp)
+> set cacheKeyFixedTimestamp := 1234627000L
+> assembly
+> checkAssemblyRebuilt
+> checkAssemblyEntryTimestamps
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# assemblyOutputPath (CacheKey.assemblyOutputPath)
+> set cacheKeyOutputName := "cache-key-relocated.jar"
+> assembly
+> checkAssemblyRebuilt
+> checkAssemblyOutputExists
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
 # assemblyRepeatableBuild (CacheKey.repeatableBuild)
 > set assemblyRepeatableBuild := false
 > assembly

--- a/src/sbt-test/caching/cache-key-invalidation-per-parameter/test
+++ b/src/sbt-test/caching/cache-key-invalidation-per-parameter/test
@@ -1,0 +1,83 @@
+> clean
+> Compile/compile
+> writeDependencyJar one
+> reload
+> assembly
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# Each cache-key input must rebuild once, then return a cache hit on the next assembly.
+
+# Compiled class output (CacheKey.assemblyInputFileStamps)
+> writeClass two
+> Compile/compile
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# Processed resource output (CacheKey.assemblyInputFileStamps)
+> writeProcessedResource two
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# Input JAR (CacheKey.assemblyInputFileStamps)
+> writeDependencyJar two
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# Built-in merge strategy for an actual conflicting entry (CacheKey.resolvedMergeStrategyInfoByTargetPath)
+> set cacheKeyMergeStrategy := "last"
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# Manifest (CacheKey.jarManifest)
+> set cacheKeyManifestValue := "two"
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# assemblyRepeatableBuild (CacheKey.repeatableBuild)
+> set assemblyRepeatableBuild := false
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# assemblyPrependShellScript (CacheKey.prependShellScript)
+> set assemblyPrependShellScript := Some(Seq("#!/usr/bin/env sh", "true"))
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# assemblyAppendContentHash (CacheKey.appendContentHash)
+> set assemblyAppendContentHash := true
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt
+
+# assemblyMaxHashLength (CacheKey.maxHashLength)
+> set assemblyMaxHashLength := 7
+> assembly
+> checkAssemblyRebuilt
+> recordAssemblyOutput
+> assembly
+> checkAssemblyNotRebuilt

--- a/src/sbt-test/caching/caching/build.sbt
+++ b/src/sbt-test/caching/caching/build.sbt
@@ -1,3 +1,60 @@
+@transient
+lazy val recordAssemblyMtime = taskKey[Unit]("Records the assembly JAR's modification time")
+
+@transient
+lazy val checkAssemblyNotRebuilt = taskKey[Unit]("Checks that unchanged assembly did not rewrite its JAR")
+
+@transient
+lazy val checkAssemblyRebuilt = taskKey[Unit]("Checks that assembly rewrote its JAR")
+
+lazy val assemblyMtimeSettings: Seq[Def.Setting[?]] = {
+  object AssemblyMtime {
+    private val recordFileName = "recorded-assembly-mtime.txt"
+
+    private def recordFile(crossTarget: File): File =
+      crossTarget / recordFileName
+
+    private def read(output: File): String =
+      java.nio.file.Files.getLastModifiedTime(output.toPath).toString
+
+    def record(output: File, crossTarget: File): Unit =
+      IO.write(recordFile(crossTarget), read(output))
+
+    def assertChange(output: File, crossTarget: File, expectedChange: Boolean): Unit = {
+      val expected = IO.read(recordFile(crossTarget)).trim
+      val actual = read(output)
+      val changed = actual != expected
+      assert(
+        changed == expectedChange,
+        if (expectedChange) s"assembly did not rewrite $output"
+        else s"unchanged assembly rewrote $output: $actual (expected $expected)",
+      )
+    }
+  }
+
+  // These utilities record the assembly JAR's timestamp and verify whether
+  // a subsequent `assembly` invocation did or did not rewrite that JAR.
+  Seq(
+    recordAssemblyMtime := {
+      AssemblyMtime.record((assembly / assemblyOutputPath).value, crossTarget.value)
+    },
+    checkAssemblyNotRebuilt := {
+      AssemblyMtime.assertChange(
+        (assembly / assemblyOutputPath).value,
+        crossTarget.value,
+        expectedChange = false,
+      )
+    },
+    checkAssemblyRebuilt := {
+      AssemblyMtime.assertChange(
+        (assembly / assemblyOutputPath).value,
+        crossTarget.value,
+        expectedChange = true,
+      )
+    },
+  )
+}
+
 lazy val root = (project in file(".")).
   settings(
     version := "0.1",
@@ -29,6 +86,9 @@ lazy val root = (project in file(".")).
       if (out.trim != "foo.txt") sys.error("unexpected output: " + out)
       ()
     },
+
+    assemblyMtimeSettings,
+
     TaskKey[Unit]("checkhash") := {
       import java.security.MessageDigest
       val s = streams.value

--- a/src/sbt-test/caching/caching/test
+++ b/src/sbt-test/caching/caching/test
@@ -12,6 +12,15 @@ $ exists target/**/jarHash.txt
 > assembly
 > check
 
+> recordAssemblyMtime
+> assembly
+> checkAssemblyNotRebuilt
+
+> recordAssemblyMtime
+> reload
+> assembly
+> checkAssemblyNotRebuilt
+
 # run again to check that the hash is the same
 # when the unzipped jars are read from cache
 # on disk
@@ -28,3 +37,15 @@ $ delete src/main/resources/foo.txt
 > genresource2
 > assembly
 > check
+
+# a missing JAR must be recreated even when its inputs are unchanged
+> recordAssemblyMtime
+$ delete target/**/foo.jar
+> assembly
+> checkAssemblyRebuilt
+
+# disabling the cache must restore the eager assembly behavior
+> set assemblyCacheOutput := false
+> recordAssemblyMtime
+> assembly
+> checkAssemblyRebuilt


### PR DESCRIPTION
Fixes #580.

## Summary

This PR restores assembly-output caching on sbt 2 and then unifies its implementation with the established sbt 1 cache lifecycle.

The shared `CacheKey` deliberately retains the original seven inputs and serializes them with `caseClassArray7` in the legacy HList field order. `Tracked.inputChanged` persists the hash of that JSON representation, so this preserves cache hits for unchanged existing sbt 1 projects and retains their `assembly-cacheKey-*` entries.

The shared controller retains the existing cache directory and file-name conventions, custom merge-strategy opt-out, logging, missing-output handling, deletion, and rebuild behavior. Platform adapters only determine how outputs are persisted:

- sbt 1 continues to store `File` values in `assembly-outputs-*`.
- sbt 2 continues to store absolute `String` paths and converts those to and from virtual outputs.

sbt 2 caches written by the initial restoration commit use named-field JSON and will rebuild once when switching to the shared positional format. This is intentional. No new cache-key inputs are introduced in this PR.

## Commit breakdown

- `ead60f9` restores sbt 2 assembly-output caching and adds Scripted coverage for hits and cache-key invalidation.
- `3658487` is the follow-up cleanup: it moves the duplicated key construction and `Tracked.inputChanged` / `lastOutput` lifecycle into common code, preserves sbt 1 compatibility, and keeps the cache-key documentation with the shared type.

## Validation

- `CI=true sbt -batch '++2.12.20' compile`
- `CI=true sbt -batch '++3.8.4' compile`
- `CI=true sbt -batch '++2.12.20' 'scripted caching/caching'`
- `CI=true sbt -batch '++3.8.4' 'scripted caching/caching'`
- `CI=true sbt -batch '++2.12.20' 'scripted caching/cache-key-invalidation-per-parameter'`
- `CI=true sbt -batch '++3.8.4' 'scripted caching/cache-key-invalidation-per-parameter'`
- `git diff --check`
- An sbt 1.10.7 project was cached with released sbt-assembly 2.4.1, switched to the local under-test plugin, and rerun unchanged. It logged `Assembly jar up to date` and the assembly JAR mtime was unchanged.
