### PR TITLE
[cleanup] Minimize cross-compilation warnings

### DIFF
--- a/src/main/scala-2.12/PluginCompat.scala
+++ b/src/main/scala-2.12/PluginCompat.scala
@@ -7,6 +7,7 @@ private[sbtassembly] object PluginCompat {
   type MainClass = sbt.Package.MainClass
 
   object CollectionConverters
+  val JavaCollectionConverters = scala.collection.JavaConverters
 
   def baseTestSettings: Seq[sbt.Def.Setting[?]] = Seq(
     AssemblyKeys.assembly / test := (()),

--- a/src/main/scala-3/PluginCompat.scala
+++ b/src/main/scala-3/PluginCompat.scala
@@ -14,6 +14,7 @@ object PluginCompat:
   type FixedTimestamp = PackageOption.FixedTimestamp
 
   val CollectionConverters = scala.collection.parallel.CollectionConverters
+  val JavaCollectionConverters = scala.jdk.CollectionConverters
 
   def baseTestSettings: Seq[sbt.Def.Setting[?]] = Seq(
     AssemblyKeys.assembly / test := TestResult.Empty,

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -1,27 +1,27 @@
 package sbtassembly
 
-import com.eed3si9n.jarjarabrams._
+import com.eed3si9n.jarjarabrams.*
 import sbt.Def.Initialize
-import sbt.Keys._
+import sbt.Keys.*
 import sbt.Package.{ manifestFormat, JarManifest, MainClass, ManifestAttributes, FixedTimestamp }
 import sbt.internal.inc.classpath.ClasspathUtil
-import sbt.io.{ DirectoryFilter => _, IO => _, Path => _, Using }
+import sbt.io.{ DirectoryFilter as _, IO as _, Path as _, Using }
 import sbt.util.{ FilesInfo, Level, ModifiedFileInfo }
-import sbt.{ File, Logger, _ }
+import sbt.{ File, Logger, *}
 import sbt.Tags.Tag
-import CacheImplicits._
-import sbtassembly.AssemblyPlugin.autoImport.{ Assembly => _, MergeStrategy => _, _ }
+import CacheImplicits.*
+import sbtassembly.AssemblyPlugin.autoImport.{ Assembly as _, MergeStrategy as _, *}
 
 import java.io.{ BufferedInputStream, ByteArrayInputStream, FileInputStream, InputStream }
 import java.net.URI
 import java.nio.file.attribute.{ BasicFileAttributeView, FileTime, PosixFilePermission }
-import java.nio.file.{ Path => NioPath, _ }
+import java.nio.file.{ Path as NioPath, *}
 import java.security.MessageDigest
 import java.time.Instant
-import java.util.jar.{ Attributes => JAttributes, JarFile, Manifest => JManifest }
+import java.util.jar.{ Attributes as JAttributes, JarFile, Manifest as JManifest }
 import scala.annotation.tailrec
 import scala.collection.GenSeq
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.*
 import scala.language.postfixOps
 import xsbti.FileConverter
 import PluginCompat.*
@@ -617,7 +617,7 @@ object Assembly {
       option match {
         case JarManifest(mergeManifest)     => Package.mergeManifests(manifest, mergeManifest)
         case MainClass(mainClassName)       => main.put(JAttributes.Name.MAIN_CLASS, mainClassName)
-        case ManifestAttributes(attrs @ _*) => main ++= attrs
+        case ManifestAttributes(attrs*)     => main ++= attrs
         case FixedTimestamp(value)          => time = value 
         case _                              =>
           log.warn("Ignored unknown package option " + option)

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -724,7 +724,7 @@ object Assembly {
   }
 
   private[sbtassembly] def hash(file: File): String =
-    bytesToString(sha1.digest(FileInfo.hash(file).hash.seq.toArray))
+    bytesToString(sha1.digest(sbt.io.Hash(file)))
 
   private[sbtassembly] def sha1 = MessageDigest.getInstance("SHA-1")
 

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -20,13 +20,12 @@ import java.security.MessageDigest
 import java.time.Instant
 import java.util.jar.{ Attributes as JAttributes, JarFile, Manifest as JManifest }
 import scala.annotation.tailrec
-import scala.collection.GenSeq
-import scala.collection.JavaConverters.*
 import scala.language.postfixOps
 import xsbti.FileConverter
 import PluginCompat.*
 import sbtcompat.PluginCompat.{FileRef, Out, toNioPath, toFile, toOutput, toNioPaths, toFiles, moduleIDStr, parseModuleIDStrAttribute}
 import CollectionConverters.{ given, * }
+import JavaCollectionConverters.*
 
 object Assembly {
   // used for contraband
@@ -225,7 +224,7 @@ object Assembly {
     implicit val ev: FileConverter = conv // used by PluginCompat
     val (jars, dirs) = timed(Level.Debug, "Separate classpath projects and all dependencies") {
       classpath.toVector
-        .sortBy(x => toNioPath(x).toAbsolutePath().toString())
+        .sortBy(x => toNioPath(x).toAbsolutePath.toString)
         .partition(x => ClasspathUtil.isArchive(toNioPath(x)))
     }
     val externalDeps = timed(Level.Debug, "Collect only external dependencies") {
@@ -264,7 +263,7 @@ object Assembly {
       if (!ao.includeBin) Vector.empty
       else dirs.flatMap { dir0 =>
         val dir = toNioPath(dir0)
-        (dir.toFile ** (-DirectoryFilter)).get().map(dir -> _.toPath())
+        (dir.toFile ** (-DirectoryFilter)).get().map(dir -> _.toPath)
       }
     val classMappings =
       timed(Level.Debug, "Collect and shade project classes") {
@@ -274,7 +273,7 @@ object Assembly {
             val sanitizedTarget =
               if (originalTarget.contains('\\')) originalTarget.replace('\\', '/')
               else originalTarget
-            classShader(sanitizedTarget, () => new BufferedInputStream(new FileInputStream(file.toFile())))
+            classShader(sanitizedTarget, () => new BufferedInputStream(new FileInputStream(file.toFile)))
               .map { case (shadedName, stream) =>
                 Project(targetJarName, sanitizedTarget, shadedName, stream)
               }
@@ -351,7 +350,7 @@ object Assembly {
         }
         val jarEntriesToWrite = timed(Level.Debug, "Sort/Parallelize merged entries") {
           if (ao.repeatableBuild) // we need the jars in a specific order to have a consistent hash
-            keptEntries.seq.sortBy(_.target)
+            keptEntries.sortBy(_.target)
           else // we actually gain performance when creating the jar in parallel, but we won't have a consistent hash
             keptEntries.par.toVector
         }
@@ -363,7 +362,7 @@ object Assembly {
         timed(Level.Debug, "Create jar") {
           if (absOutput.isDirectory) {
             val invalidPath = absOutput.toPath.normalize
-            log.error(s"expected a file name for assemblyOutputPath, but found a directory: ${invalidPath}; fix the setting or delete the directory")
+            log.error(s"expected a file name for assemblyOutputPath, but found a directory: $invalidPath; fix the setting or delete the directory")
             throw new RuntimeException("Exiting task")
           } else {
             IO.delete(absOutput)
@@ -572,7 +571,7 @@ object Assembly {
 
   private[sbtassembly] def createJar(
       output: File,
-      entries: GenSeq[JarEntry],
+      entries: Seq[JarEntry],
       manifest: JManifest,
       localTime: Long
   ): Unit = {
@@ -654,16 +653,15 @@ object Assembly {
       .partition(_.isRight)
     if (failures.nonEmpty) {
       log.error(s"${failures.size} error(s) were encountered during the merge:")
-      throw new RuntimeException(failures.map(_.left.get).mkString(newLine, newLine, ""))
+      throw new RuntimeException(lefts(failures.iterator).mkString(newLine, newLine, ""))
     }
-    successfullyMerged.map(_.right.get).toVector
+    rights(successfullyMerged.iterator).toVector
   }
 
   private[sbtassembly] def reportMergeResults(mergedEntries: Vector[MergedEntry], log: Logger): Unit =
     mergedEntries
       .groupBy(entry => entry.mergeStrategy.isBuiltIn -> entry.mergeStrategy.name)
       .values
-      .seq // we need to switch to sequential here to not mess up the detail logs
       .foreach { entries => // TODO figure out how to use BufferedAppender so we can keep this parallel
         val mergeStrategy = entries.head.mergeStrategy
         val entriesToNotify = entries.filter(entry => entry.origins.size >= mergeStrategy.notifyThreshold)
@@ -676,7 +674,7 @@ object Assembly {
             mergeStrategy.summaryLogLevel,
             s"$totalMerged file(s) merged using strategy '${strategyDisplayName(mergeStrategy)}'$notifyDetails"
           )
-          log.log(mergeStrategy.detailLogLevel, entriesToNotify.seq.mkString(""))
+          log.log(mergeStrategy.detailLogLevel, entriesToNotify.iterator.mkString(""))
         }
       }
 
@@ -707,11 +705,11 @@ object Assembly {
             }
         }
         .filter { case ((_, _), conflictingDirs) =>
-          conflictingDirs.nonEmpty
+          conflictingDirs.iterator.nonEmpty
         }
         .map { case ((target, conflictingFiles), conflictingDirectories) =>
           val sources = conflictingFiles.mkString(newLineIndented)
-          val directories = conflictingDirectories.mkString(newLineIndented)
+          val directories = conflictingDirectories.iterator.mkString(newLineIndented)
           Left(
             s"Files to be written at '$target' have the same name as directories to be written:$newLineIndented$directories$newLineIndented$sources"
           )
@@ -719,9 +717,15 @@ object Assembly {
 
     if (filesConflictingWithDirs.nonEmpty) {
       log.error(s"${filesConflictingWithDirs.size} error(s) were still encountered after the merge:")
-      throw new RuntimeException(filesConflictingWithDirs.map(_.left.get).mkString(newLine, newLine, ""))
+      throw new RuntimeException(lefts(filesConflictingWithDirs.iterator).mkString(newLine, newLine, ""))
     }
   }
+
+  private[sbtassembly] def lefts[A, B](values: Iterator[Either[A, B]]): Iterator[A] =
+    values.collect { case Left(value) => value }
+
+  private[sbtassembly] def rights[A, B](values: Iterator[Either[A, B]]): Iterator[B] =
+    values.collect { case Right(value) => value }
 
   private[sbtassembly] def hash(file: File): String =
     bytesToString(sha1.digest(sbt.io.Hash(file)))
@@ -747,10 +751,10 @@ object Assembly {
       bytesToString(messageDigest.digest())
     }
 
-  private[sbtassembly] def bytesToString(bytes: Seq[Byte]): String =
-    bytes map {
+  private[sbtassembly] def bytesToString(bytes: Array[Byte]): String =
+    bytes.iterator.map {
       "%02x".format(_)
-    } mkString
+    }.mkString
 }
 
 object PathList {

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -10,7 +10,7 @@ import sbt.util.{ FilesInfo, Level, ModifiedFileInfo }
 import sbt.{ File, Logger, _ }
 import sbt.Tags.Tag
 import CacheImplicits._
-import sbtassembly.AssemblyPlugin.autoImport.{ Assembly => _, _ }
+import sbtassembly.AssemblyPlugin.autoImport.{ Assembly => _, MergeStrategy => _, _ }
 
 import java.io.{ BufferedInputStream, ByteArrayInputStream, FileInputStream, InputStream }
 import java.net.URI

--- a/src/main/scala/sbtassembly/AssemblyCache.scala
+++ b/src/main/scala/sbtassembly/AssemblyCache.scala
@@ -40,7 +40,7 @@ private[sbtassembly] final case class CacheKey(
 )
 
 private[sbtassembly] object CacheKey {
-  import CacheImplicits._
+  import CacheImplicits.*
   import sbt.Package.manifestFormat
 
   implicit val format: JsonFormat[CacheKey] = BasicJsonProtocol.caseClassArray9(

--- a/src/main/scala/sbtassembly/AssemblyPlugin.scala
+++ b/src/main/scala/sbtassembly/AssemblyPlugin.scala
@@ -1,7 +1,7 @@
 package sbtassembly
 
 import com.eed3si9n.jarjarabrams
-import sbt.Keys._
+import sbt.Keys.*
 import sbt.{ given, * }
 import PluginCompat.*
 import sbtcompat.PluginCompat.*
@@ -26,7 +26,7 @@ object AssemblyPlugin extends sbt.AutoPlugin {
         )
     }
   }
-  import autoImport.{ baseAssemblySettings => _, Assembly => _, _ }
+  import autoImport.{ baseAssemblySettings as _, Assembly as _, *}
 
   override lazy val globalSettings: Seq[Def.Setting[?]] = Seq(
     assemblyMergeStrategy := MergeStrategy.defaultMergeStrategy,

--- a/src/main/scala/sbtassembly/MergeStrategy.scala
+++ b/src/main/scala/sbtassembly/MergeStrategy.scala
@@ -2,13 +2,13 @@ package sbtassembly
 
 import sbt.io.{ IO, Using }
 import sbt.util.Level
-import sbtassembly.Assembly._
+import sbtassembly.Assembly.*
 import sbtassembly.AssemblyUtils.AppendEofInputStream
 
 import java.io.{ BufferedReader, ByteArrayInputStream, InputStreamReader, SequenceInputStream }
 import java.nio.charset.Charset
 import java.util.Collections
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.*
 import scala.reflect.io.Streamable
 
 /**
@@ -185,11 +185,11 @@ object MergeStrategy {
   val defaultMergeStrategy: String => MergeStrategy = {
     case x if isConfigFile(x) =>
       MergeStrategy.concat
-    case PathList(ps @ _*) if isReadme(ps.last) || isLicenseFile(ps.last) =>
+    case PathList(ps*) if isReadme(ps.last) || isLicenseFile(ps.last) =>
       MergeStrategy.rename
-    case PathList(ps @ _*) if isSystemJunkFile(ps.last) =>
+    case PathList(ps*) if isSystemJunkFile(ps.last) =>
       MergeStrategy.discard
-    case PathList("META-INF", xs @ _*) =>
+    case PathList("META-INF", xs*) =>
       xs map {
         _.toLowerCase
       } match {

--- a/src/main/scala/sbtassembly/MergeStrategy.scala
+++ b/src/main/scala/sbtassembly/MergeStrategy.scala
@@ -3,12 +3,12 @@ package sbtassembly
 import sbt.io.{ IO, Using }
 import sbt.util.Level
 import sbtassembly.Assembly.*
+import sbtassembly.PluginCompat.JavaCollectionConverters.*
 import sbtassembly.AssemblyUtils.AppendEofInputStream
 
 import java.io.{ BufferedReader, ByteArrayInputStream, InputStreamReader, SequenceInputStream }
 import java.nio.charset.Charset
 import java.util.Collections
-import scala.collection.JavaConverters.*
 import scala.reflect.io.Streamable
 
 /**
@@ -220,7 +220,7 @@ object MergeStrategy {
       strategy: MergeStrategy,
       dependencies: Vector[Dependency]
   ): Either[String, MergedEntry] =
-    strategy(dependencies).right.map(entry => MergedEntry(entry, dependencies, strategy))
+    strategy(dependencies).map(entry => MergedEntry(entry, dependencies, strategy))
 }
 
 object CustomMergeStrategy {


### PR DESCRIPTION
# Summary

Minimizes warnings emitted while cross-compiling sbt-assembly for Scala 2.12 and Scala 3.

# Stacked PR

This PR is based on the branch from [#581](https://github.com/sbt/sbt-assembly/pull/581), so it currently includes that PR's assembly-output-caching changes as well. Once #581 is merged, this PR's diff against `develop` will become more compact and show only these cleanup changes.

# Changes

- use source-version-specific Java collection converter aliases;
- replace deprecated collection and `Either` APIs;
- centralize `Left` and `Right` extraction helpers.

# Validation

`sbt -batch clean '++2.12.x' compile '++3.x' compile`
