### PR TITLE
Include shade rules in the assembly cache key

### DIFF
--- a/src/main/scala/sbtassembly/AssemblyCache.scala
+++ b/src/main/scala/sbtassembly/AssemblyCache.scala
@@ -13,6 +13,9 @@ import sjsonnew.{ BasicJsonProtocol, JsonFormat }
  * @param assemblyInputFileStamps               modification-time information for compiled class/resource outputs
  *                                              and selected JARs on the resolved assembly classpath; source files are not watched directly
  * @param resolvedMergeStrategyInfoByTargetPath resolved merge-strategy information, indexed by target path
+ * @param shadeRules                            configured shade rules, rendered as strings. Rules reach the target paths
+ *                                              only when they rename an entry, so keep rules and changes to a rule's
+ *                                              target scope are otherwise invisible to this key
  * @param jarManifest                           manifest written to the output JAR
  * @param repeatableBuild                       whether output JAR entries are sorted by target path before writing to
  *                                              make the output bytes deterministic for reproducible builds
@@ -30,6 +33,7 @@ import sjsonnew.{ BasicJsonProtocol, JsonFormat }
 private[sbtassembly] final case class CacheKey(
   assemblyInputFileStamps: FilesInfo[ModifiedFileInfo],
   resolvedMergeStrategyInfoByTargetPath: Map[String, (Boolean, String)],
+  shadeRules: Seq[String],
   jarManifest: JManifest,
   repeatableBuild: Boolean,
   prependShellScript: Option[Seq[String]],
@@ -43,11 +47,12 @@ private[sbtassembly] object CacheKey {
   import CacheImplicits.*
   import sbt.Package.manifestFormat
 
-  implicit val format: JsonFormat[CacheKey] = BasicJsonProtocol.caseClassArray9(
+  implicit val format: JsonFormat[CacheKey] = BasicJsonProtocol.caseClassArray10(
     CacheKey.apply,
     key => Some((
       key.assemblyInputFileStamps,
       key.resolvedMergeStrategyInfoByTargetPath,
+      key.shadeRules,
       key.jarManifest,
       key.repeatableBuild,
       key.prependShellScript,
@@ -71,6 +76,7 @@ private[sbtassembly] object AssemblyCache {
     CacheKey(
       assemblyInputFileStamps = lastModified(inputFiles),
       resolvedMergeStrategyInfoByTargetPath = mergeStrategiesByPathList,
+      shadeRules = ao.shadeRules.map(_.toString),
       jarManifest = jarManifest,
       repeatableBuild = ao.repeatableBuild,
       prependShellScript = ao.prependShellScript,

--- a/src/sbt-test/caching/shaderule-invalidation/build.sbt
+++ b/src/sbt-test/caching/shaderule-invalidation/build.sbt
@@ -1,5 +1,11 @@
 lazy val keepPatterns = settingKey[Seq[String]]("keep patterns under test")
 
+@transient
+lazy val recordAssemblyMtime = taskKey[Unit]("Records the assembly JAR's modification time")
+
+@transient
+lazy val checkAssemblyNotRebuilt = taskKey[Unit]("Checks that an unchanged assembly did not rewrite its JAR")
+
 def classPresent(jar: File, entry: String): Boolean = {
   val zf = new java.util.zip.ZipFile(jar)
   try zf.getEntry(entry) != null finally zf.close()
@@ -17,6 +23,16 @@ lazy val root = (project in file("."))
       val jar = (assembly / assemblyOutputPath).value
       assert(classPresent(jar, "keep/Kept$.class"), "keep/Kept$.class missing")
       assert(!classPresent(jar, "removed/Dropped$.class"), "removed/Dropped$.class should be dropped")
+    },
+    recordAssemblyMtime := {
+      val jar = (assembly / assemblyOutputPath).value
+      IO.write(crossTarget.value / "recorded-mtime.txt", java.nio.file.Files.getLastModifiedTime(jar.toPath).toString)
+    },
+    checkAssemblyNotRebuilt := {
+      val jar = (assembly / assemblyOutputPath).value
+      val expected = IO.read(crossTarget.value / "recorded-mtime.txt").trim
+      val actual = java.nio.file.Files.getLastModifiedTime(jar.toPath).toString
+      assert(actual == expected, s"unchanged assembly rewrote $jar: $actual (expected $expected)")
     },
     TaskKey[Unit]("checkBothKept") := {
       val jar = (assembly / assemblyOutputPath).value

--- a/src/sbt-test/caching/shaderule-invalidation/build.sbt
+++ b/src/sbt-test/caching/shaderule-invalidation/build.sbt
@@ -1,0 +1,29 @@
+lazy val keepPatterns = settingKey[Seq[String]]("keep patterns under test")
+
+def classPresent(jar: File, entry: String): Boolean = {
+  val zf = new java.util.zip.ZipFile(jar)
+  try zf.getEntry(entry) != null finally zf.close()
+}
+
+lazy val root = (project in file("."))
+  .settings(
+    version := "0.1",
+    scalaVersion := "2.12.18",
+    exportJars := false,
+    assembly / assemblyJarName := "foo.jar",
+    keepPatterns := Seq("keep.**"),
+    assembly / assemblyShadeRules := Seq(ShadeRule.keep(keepPatterns.value: _*).inProject),
+    TaskKey[Unit]("checkKeptOnly") := {
+      val jar = (assembly / assemblyOutputPath).value
+      assert(classPresent(jar, "keep/Kept$.class"), "keep/Kept$.class missing")
+      assert(!classPresent(jar, "removed/Dropped$.class"), "removed/Dropped$.class should be dropped")
+    },
+    TaskKey[Unit]("checkBothKept") := {
+      val jar = (assembly / assemblyOutputPath).value
+      val kept = classPresent(jar, "keep/Kept$.class")
+      val dropped = classPresent(jar, "removed/Dropped$.class")
+      streams.value.log.info(s"kept=$kept droppedClassPresent=$dropped")
+      assert(kept, "keep/Kept$.class missing")
+      assert(dropped, "STALE CACHE: keep rule widened to removed.** but removed/Dropped$.class is still absent")
+    }
+  )

--- a/src/sbt-test/caching/shaderule-invalidation/project/plugins.sbt
+++ b/src/sbt-test/caching/shaderule-invalidation/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.eed3si9n" % "sbt-assembly" % pluginVersion)
+}

--- a/src/sbt-test/caching/shaderule-invalidation/src/main/scala/keep/Kept.scala
+++ b/src/sbt-test/caching/shaderule-invalidation/src/main/scala/keep/Kept.scala
@@ -1,0 +1,2 @@
+package keep
+object Kept { def hi = "kept" }

--- a/src/sbt-test/caching/shaderule-invalidation/src/main/scala/removed/Dropped.scala
+++ b/src/sbt-test/caching/shaderule-invalidation/src/main/scala/removed/Dropped.scala
@@ -1,0 +1,2 @@
+package removed
+object Dropped { def hi = "dropped" }

--- a/src/sbt-test/caching/shaderule-invalidation/test
+++ b/src/sbt-test/caching/shaderule-invalidation/test
@@ -9,3 +9,8 @@
 > set keepPatterns := Seq("keep.**", "removed.**")
 > assembly
 > checkBothKept
+
+# the widened rule is now part of the cache key, so a repeat is still a cache hit
+> recordAssemblyMtime
+> assembly
+> checkAssemblyNotRebuilt

--- a/src/sbt-test/caching/shaderule-invalidation/test
+++ b/src/sbt-test/caching/shaderule-invalidation/test
@@ -1,0 +1,11 @@
+> clean
+> Compile/compile
+
+# baseline: only keep.** is kept
+> assembly
+> checkKeptOnly
+
+# widen the keep rule; nothing else changes
+> set keepPatterns := Seq("keep.**", "removed.**")
+> assembly
+> checkBothKept


### PR DESCRIPTION
Fixes #583.

`CacheKey` had no shade rule field, so widening a `ShadeRule.keep` pattern left the key identical and `assembly` returned the cached jar. Rules are now stored as strings, which also covers a rule changing its `.inAll` or `.inLibrary` scope. Scripted test included.
