### PR TITLE
Exclude Scala 3 library JARs from the assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ NOTE: If you use [`-jar` option for `java`](http://docs.oracle.com/javase/7/docs
 
 ### Excluding Scala library JARs
 
-To exclude Scala library (JARs that start with `scala-` and are included in the binary Scala distribution) to run with `scala` command,
+To exclude Scala library (JARs that are included in the binary Scala distribution, such as `scala-library`, `scala3-library` and `tasty-core`) to run with `scala` command,
 
 ```scala
 lazy val app = (project in file("app"))

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -238,11 +238,17 @@ object Assembly {
     }
     val scalaLibraries = {
       val scalaVersionParts = VersionNumber(ao.scalaVersion)
-      val epoch = scalaVersionParts._1
       val major = scalaVersionParts._2
-      if (epoch.exists(_ >= 3L)) scala3Libraries
-      else if (epoch.contains(2L) && major.exists(_ >= 13L)) scala213AndLaterLibraries
-      else scalaPre213Libraries
+      scalaVersionParts._1 match {
+        case Some(3L)                           => scala3Libraries
+        case Some(2L) if major.exists(_ >= 13L) => scala213AndLaterLibraries
+        case Some(2L)                           => scalaPre213Libraries
+        case _ =>
+          sys.error(
+            s"""Unsupported Scala version "${ao.scalaVersion}" in assemblyOption. """ +
+              "sbt-assembly only knows which JARs ship with the Scala 2 and Scala 3 distributions."
+          )
+      }
     }
 
     val filteredJars = timed(Level.Debug, "Filter jars") {

--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -52,6 +52,8 @@ object Assembly {
   )
   private[sbtassembly] val scala213AndLaterLibraries =
     Vector("scala-actors", "scala-compiler", "scala-continuations", "scala-library", "scala-reflect")
+  private[sbtassembly] val scala3Libraries =
+    Vector("scala-library", "scala3-compiler", "scala3-interfaces", "scala3-library", "tasty-core")
 
   /* Closeable resources */
   private[sbtassembly] val jarFileSystemResource =
@@ -236,9 +238,11 @@ object Assembly {
     }
     val scalaLibraries = {
       val scalaVersionParts = VersionNumber(ao.scalaVersion)
-      val isScala213AndLater =
-        scalaVersionParts.numbers.length >= 2 && scalaVersionParts._1.get >= 2 && scalaVersionParts._2.get >= 13
-      if (isScala213AndLater) scala213AndLaterLibraries else scalaPre213Libraries
+      val epoch = scalaVersionParts._1
+      val major = scalaVersionParts._2
+      if (epoch.exists(_ >= 3L)) scala3Libraries
+      else if (epoch.contains(2L) && major.exists(_ >= 13L)) scala213AndLaterLibraries
+      else scalaPre213Libraries
     }
 
     val filteredJars = timed(Level.Debug, "Filter jars") {

--- a/src/sbt-test/sbt-assembly/scala-epoch/build.sbt
+++ b/src/sbt-test/sbt-assembly/scala-epoch/build.sbt
@@ -1,0 +1,15 @@
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "3.3.4"
+
+lazy val known = (project in file("known"))
+  .settings(
+    name := "known",
+    Compile / scalaSource := (ThisBuild / baseDirectory).value / "src" / "main" / "scala"
+  )
+
+lazy val unknown = (project in file("unknown"))
+  .settings(
+    name := "unknown",
+    Compile / scalaSource := (ThisBuild / baseDirectory).value / "src" / "main" / "scala",
+    assembly / assemblyOption ~= { _.withScalaVersion("4.0.0") }
+  )

--- a/src/sbt-test/sbt-assembly/scala-epoch/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/scala-epoch/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.eed3si9n" % "sbt-assembly" % pluginVersion)
+}

--- a/src/sbt-test/sbt-assembly/scala-epoch/src/main/scala/hello.scala
+++ b/src/sbt-test/sbt-assembly/scala-epoch/src/main/scala/hello.scala
@@ -1,0 +1,3 @@
+object Main:
+  def main(args: Array[String]): Unit =
+    println("hello")

--- a/src/sbt-test/sbt-assembly/scala-epoch/test
+++ b/src/sbt-test/sbt-assembly/scala-epoch/test
@@ -1,0 +1,5 @@
+# a known Scala epoch assembles
+> known/assembly
+
+# an unrecognized epoch fails instead of guessing a Scala library list
+-> unknown/assembly

--- a/src/sbt-test/sbt-assembly/scala3/build.sbt
+++ b/src/sbt-test/sbt-assembly/scala3/build.sbt
@@ -1,0 +1,50 @@
+import scala.jdk.CollectionConverters.*
+
+version := "0.1"
+scalaVersion := "3.3.4"
+assemblyPackageScala / assembleArtifact := false
+
+def entries(jar: File): Set[String] = {
+  val zip = new java.util.zip.ZipFile(jar)
+  try zip.entries.asScala.map(_.getName).toSet
+  finally zip.close()
+}
+
+lazy val root = (project in file("."))
+  .settings(
+    name := "foo",
+    assembly / mainClass := Some("Main"),
+
+    TaskKey[Unit]("checkScalaExcluded") := {
+      val found = entries(crossTarget.value / "foo-assembly-0.1.jar").filter(_.startsWith("scala/"))
+      if (found.nonEmpty)
+        sys.error(s"expected no Scala library entries, found ${found.size}, e.g. ${found.take(5).toList}")
+    },
+
+    TaskKey[Unit]("checkScalaPackaged") := {
+      val found = entries(crossTarget.value / "scala-library-3.3.4-assembly.jar")
+      val expected = Set(
+        "scala/CanEqual.class",
+        "scala/reflect/Enum.class",
+        "scala/collection/immutable/List.class"
+      )
+      val missing = expected -- found
+      if (missing.nonEmpty) sys.error(s"missing from the Scala library JAR: ${missing.toList.sorted}")
+    },
+
+    TaskKey[Unit]("run1") := {
+      val out = sys.process.Process("java", Seq("-cp",
+        (crossTarget.value / "foo-assembly-0.1.jar").toString,
+        "Main")).!!
+      if (out.trim != "hello") sys.error("unexpected output: " + out)
+    },
+
+    TaskKey[Unit]("run2") := {
+      val out = sys.process.Process("java", Seq("-cp",
+        (crossTarget.value / "scala-library-3.3.4-assembly.jar").toString +
+        (if (scala.util.Properties.isWin) ";" else ":") +
+        (crossTarget.value / "foo-assembly-0.1.jar").toString,
+        "Main")).!!
+      if (out.trim != "hello") sys.error("unexpected output: " + out)
+    }
+  )

--- a/src/sbt-test/sbt-assembly/scala3/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/scala3/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.eed3si9n" % "sbt-assembly" % pluginVersion)
+}

--- a/src/sbt-test/sbt-assembly/scala3/src/main/scala/hello.scala
+++ b/src/sbt-test/sbt-assembly/scala3/src/main/scala/hello.scala
@@ -1,0 +1,6 @@
+enum Color:
+  case Red, Green
+
+object Main:
+  def main(args: Array[String]): Unit =
+    println(if Color.Red.ordinal == 0 then "hello" else "bye")

--- a/src/sbt-test/sbt-assembly/scala3/test
+++ b/src/sbt-test/sbt-assembly/scala3/test
@@ -1,0 +1,15 @@
+# the Scala 3 library must not leak into the assembly
+> assembly
+$ exists target/**/foo-assembly-0.1.jar
+> checkScalaExcluded
+
+# without the Scala library on the classpath this cannot run
+-> run1
+
+# the Scala 3 library must end up in the assemblyPackageScala JAR
+> assemblyPackageScala
+$ exists target/**/scala-library-3.3.4-assembly.jar
+> checkScalaPackaged
+
+# the two JARs together are enough to run
+> run2


### PR DESCRIPTION
Fixes #544 and #467.

The Scala library list had no `scala3-library`, and `isScala213AndLater` was false for 3.x, so Scala 3 fell back to the pre-2.13 list. `includeScala = false` then dropped `scala-library` but kept all of `scala3-library`, and `scala-xml` was dropped too. Scripted test included.