### PR TITLE
Bound the number of open dependency jar handles

### DIFF
--- a/src/main/scala/sbtassembly/Assembly.scala
+++ b/src/main/scala/sbtassembly/Assembly.scala
@@ -18,7 +18,7 @@ import java.nio.file.attribute.{ BasicFileAttributeView, FileTime, PosixFilePerm
 import java.nio.file.{ Path as NioPath, *}
 import java.security.MessageDigest
 import java.time.Instant
-import java.util.jar.{ Attributes as JAttributes, JarFile, Manifest as JManifest }
+import java.util.jar.{ Attributes as JAttributes, Manifest as JManifest }
 import scala.annotation.tailrec
 import scala.language.postfixOps
 import xsbti.FileConverter
@@ -291,7 +291,8 @@ object Assembly {
           ),
         log
       )
-    val (jarFiles, jarFileEntries) = timed(Level.Debug, "Collect and shade dependency entries") {
+    val jarFilePool = JarFilePool()
+    val jarFileEntries = timed(Level.Debug, "Collect and shade dependency entries") {
       val (externalJars, projectJars) = filteredJars.partition(externalDeps.contains)
       (projectJars ++ externalJars).par.map { jar =>
         val module = jar.metadata
@@ -299,20 +300,23 @@ object Assembly {
           .map(parseModuleIDStrAttribute)
           .map(m => ModuleCoordinate(m.organization, m.name, m.revision))
           .getOrElse(ModuleCoordinate("", jar.data.name.replaceAll(".jar", ""), ""))
-        val jarFile = new JarFile(toFile(jar))
-        jarFile -> jarFile
-          .entries()
-          .asScala
-          .filterNot(_.isDirectory)
-          .toVector
-          .par
-          .flatMap { entry =>
-            jarShader(module)(entry.getName, () => jarFile.getInputStream(entry))
-              .map { case (shadedName, stream) =>
-                Library(module, entry.getName, shadedName, stream)
-              }
-          }
-      }.unzip
+        val jarPath = toFile(jar)
+        jarFilePool.withJar(jarPath) { jarFile =>
+          jarFile
+            .entries()
+            .asScala
+            .filterNot(_.isDirectory)
+            .toVector
+            .par
+            .flatMap { entry =>
+              val entryName = entry.getName
+              jarShader(module)(entryName, () => jarFilePool.stream(jarPath, entryName))
+                .map { case (shadedName, stream) =>
+                  Library(module, entryName, shadedName, stream)
+                }
+            }
+        }
+      }
     }
 
     try {
@@ -438,7 +442,8 @@ object Assembly {
       } else buildAssembly()
     } finally
       timed(Level.Debug, "Close library jar references") {
-        jarFiles.foreach(_.close())
+        log.debug(jarFilePool.stats)
+        jarFilePool.close()
       }
   }
 

--- a/src/main/scala/sbtassembly/JarFilePool.scala
+++ b/src/main/scala/sbtassembly/JarFilePool.scala
@@ -1,0 +1,129 @@
+package sbtassembly
+
+import java.io.{ File, FilterInputStream, InputStream }
+import java.util.jar.JarFile
+
+/**
+ * A bounded, reference-counted pool of open [[JarFile]] handles.
+ *
+ * Only up to `maxOpen` jars are kept open at a time; the least recently used unreferenced handle is
+ * closed to make room. A handle is never closed while one of its streams is still being read.
+ */
+private[sbtassembly] final class JarFilePool(maxOpen: Int) extends AutoCloseable {
+  private final class Handle(val jar: JarFile) {
+    var refs: Int = 0
+  }
+
+  private val open = new java.util.LinkedHashMap[String, Handle](16, 0.75f, true)
+  private var closed = false
+  private var opens = 0L
+  private var reuses = 0L
+
+  private def acquire(file: File): (String, Handle) = synchronized {
+    if (closed) sys.error("JarFilePool is closed")
+    val key = file.getAbsolutePath
+    val handle = open.get(key) match {
+      case null =>
+        opens += 1
+        val h = new Handle(new JarFile(file))
+        open.put(key, h)
+        h
+      case h =>
+        reuses += 1
+        h
+    }
+    handle.refs += 1
+    evict()
+    key -> handle
+  }
+
+  private def release(handle: Handle): Unit = synchronized {
+    handle.refs -= 1
+    evict()
+  }
+
+  private def evict(): Unit =
+    if (open.size > maxOpen) {
+      val it = open.entrySet().iterator()
+      while (it.hasNext && open.size > maxOpen) {
+        val handle = it.next().getValue
+        if (handle.refs == 0) {
+          handle.jar.close()
+          it.remove()
+        }
+      }
+    }
+
+  /** Runs `f` with the jar open, keeping it open for the duration of the call */
+  def withJar[A](file: File)(f: JarFile => A): A = {
+    val (_, handle) = acquire(file)
+    try f(handle.jar)
+    finally release(handle)
+  }
+
+  /** Opens a stream for `entryName`, opening (or reusing) the jar and releasing it on close */
+  def stream(file: File, entryName: String): InputStream = {
+    val (key, handle) = acquire(file)
+    val entry = handle.jar.getEntry(entryName)
+    if (entry == null) {
+      release(handle)
+      sys.error(s"Entry $entryName disappeared from $key")
+    }
+    new FilterInputStream(handle.jar.getInputStream(entry)) {
+      private var released = false
+      override def close(): Unit = {
+        try super.close()
+        finally
+          synchronized {
+            if (!released) {
+              released = true
+              release(handle)
+            }
+          }
+      }
+    }
+  }
+
+  def stats: String = synchronized(s"jar handles opened = $opens, reused = $reuses, still open = ${open.size}")
+
+  override def close(): Unit = synchronized {
+    closed = true
+    val it = open.entrySet().iterator()
+    while (it.hasNext) {
+      it.next().getValue.jar.close()
+      it.remove()
+    }
+  }
+}
+
+private[sbtassembly] object JarFilePool {
+  private val maxOpenJarsProperty = "sbtassembly.maxOpenJars"
+  private val absoluteMaxOpen = 512
+  private val minimumMaxOpen = 16
+
+  /** Descriptors left for the rest of the build, which holds its own classpath open */
+  private val reservedFileDescriptors = 256
+
+  /** The number of jars to keep open, kept well under the file descriptor limit of the process */
+  def defaultMaxOpen: Int =
+    sys.props
+      .get(maxOpenJarsProperty)
+      .flatMap(value => scala.util.Try(value.toInt).toOption)
+      .getOrElse {
+        val fileDescriptorLimit =
+          try
+            java.lang.management.ManagementFactory.getOperatingSystemMXBean match {
+              case os: com.sun.management.UnixOperatingSystemMXBean => os.getMaxFileDescriptorCount
+              case _                                                => -1L
+            }
+          catch { case _: Throwable => -1L }
+        if (fileDescriptorLimit <= 0) absoluteMaxOpen
+        else
+          math.max(
+            minimumMaxOpen,
+            math.min(absoluteMaxOpen, ((fileDescriptorLimit - reservedFileDescriptors) / 2).toInt)
+          )
+      }
+
+  def apply(): JarFilePool = new JarFilePool(math.max(1, defaultMaxOpen))
+}

--- a/src/main/scala/sbtassembly/MergeStrategy.scala
+++ b/src/main/scala/sbtassembly/MergeStrategy.scala
@@ -3,12 +3,10 @@ package sbtassembly
 import sbt.io.{ IO, Using }
 import sbt.util.Level
 import sbtassembly.Assembly.*
-import sbtassembly.PluginCompat.JavaCollectionConverters.*
 import sbtassembly.AssemblyUtils.AppendEofInputStream
 
-import java.io.{ BufferedReader, ByteArrayInputStream, InputStreamReader, SequenceInputStream }
+import java.io.{ BufferedReader, ByteArrayInputStream, InputStream, InputStreamReader, SequenceInputStream }
 import java.nio.charset.Charset
-import java.util.Collections
 import scala.reflect.io.Streamable
 
 /**
@@ -108,8 +106,14 @@ object MergeStrategy {
    * @param separator a custom content separator, defaulted to the System line separator
    */
   def concat(separator: String = newLine): MergeStrategy = MergeStrategy("Concat") { conflicts =>
-    val streamsWithNewLine = conflicts.map(_.stream()).map(AppendEofInputStream(_, separator))
-    val concatenatedStream = () => new SequenceInputStream(Collections.enumeration(streamsWithNewLine.asJava))
+    val concatenatedStream = () => {
+      val streams = new java.util.Enumeration[InputStream] {
+        private val remaining = conflicts.iterator
+        override def hasMoreElements: Boolean = remaining.hasNext
+        override def nextElement(): InputStream = AppendEofInputStream(remaining.next().stream(), separator)
+      }
+      new SequenceInputStream(streams)
+    }
     Right(Vector(JarEntry(conflicts.head.target, concatenatedStream)))
   }
 

--- a/src/sbt-test/sbt-assembly/bounded-jar-handles/build.sbt
+++ b/src/sbt-test/sbt-assembly/bounded-jar-handles/build.sbt
@@ -1,0 +1,31 @@
+name := "foo"
+version := "0.1"
+scalaVersion := "2.12.18"
+libraryDependencies += "commons-io" % "commons-io" % "2.4"
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "0.9.29"
+assembly / assemblyJarName := "foo.jar"
+
+TaskKey[Unit]("keepOneJarOpen") := {
+  System.setProperty("sbtassembly.maxOpenJars", "1")
+  ()
+}
+
+TaskKey[Unit]("check") := {
+  IO.withTemporaryDirectory { dir =>
+    IO.unzip(crossTarget.value / "foo.jar", dir)
+    mustExist(dir / "Main.class")
+    mustExist(dir / "scala" / "Predef.class")
+    mustExist(dir / "org" / "apache" / "commons" / "io" / "IOUtils.class")
+    mustExist(dir / "org" / "slf4j" / "Logger.class")
+    mustExist(dir / "ch" / "qos" / "logback" / "core" / "Context.class")
+    mustExist(dir / "ch" / "qos" / "logback" / "classic" / "Logger.class")
+  }
+  val process = sys.process.Process("java", Seq("-jar", (crossTarget.value / "foo.jar").toString))
+  val out = process.!!
+  if (out.trim != "hello") sys.error("unexpected output: " + out)
+  ()
+}
+
+def mustExist(f: File): Unit = {
+  if (!f.exists) sys.error("file " + f + " does not exist!")
+}

--- a/src/sbt-test/sbt-assembly/bounded-jar-handles/project/plugins.sbt
+++ b/src/sbt-test/sbt-assembly/bounded-jar-handles/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.eed3si9n" % "sbt-assembly" % pluginVersion)
+}

--- a/src/sbt-test/sbt-assembly/bounded-jar-handles/src/main/scala/hello.scala
+++ b/src/sbt-test/sbt-assembly/bounded-jar-handles/src/main/scala/hello.scala
@@ -1,0 +1,3 @@
+object Main {
+  def main(args: Array[String]) { println("hello") }
+}

--- a/src/sbt-test/sbt-assembly/bounded-jar-handles/test
+++ b/src/sbt-test/sbt-assembly/bounded-jar-handles/test
@@ -1,0 +1,8 @@
+# force the jar handle pool to evict on every read
+> keepOneJarOpen
+
+> assembly
+$ exists target/**/foo.jar
+
+# every entry must still be readable after its jar was closed and reopened
+> check


### PR DESCRIPTION
Fixes #527, a regression from 1.2.0. assemble opened a JarFile per dependency jar and held them all open until the task finished, so builds with a few hundred jars ran out of file descriptors. Handles now go through a bounded LRU pool. Same bytes out, no measurable slowdown.
